### PR TITLE
perf: speed up stop search and Saved sheet

### DIFF
--- a/app/api/kmb/fares/route.ts
+++ b/app/api/kmb/fares/route.ts
@@ -6,6 +6,8 @@ import type { KmbRouteStopLite } from "@/lib/eta/client";
 import { kmbFareCacheControlHeader, getCachedKmbVariantStops, getStopToTerminusFare } from "@/lib/eta/kmb-fares";
 import { getKmbRouteStops } from "@/lib/eta/kmb";
 
+export const runtime = "nodejs";
+
 const VariantSchema = z.object({
   route: z.string(),
   dir: z.string(),

--- a/app/api/kmb/route-stop/route.ts
+++ b/app/api/kmb/route-stop/route.ts
@@ -4,6 +4,8 @@ import { ApiError, UpstreamTimeoutError } from "@/lib/eta/http";
 import { kmbDailyCacheControlHeader, secondsUntilNextKmbDailyUpdate } from "@/lib/eta/kmb-cache";
 import { getKmbRouteStops } from "@/lib/eta/kmb";
 
+export const runtime = "nodejs";
+
 export async function GET() {
   const revalidateSeconds = secondsUntilNextKmbDailyUpdate();
 

--- a/app/api/kmb/stop-etas/route.ts
+++ b/app/api/kmb/stop-etas/route.ts
@@ -9,6 +9,8 @@ import { getKmbRouteStops, getKmbStopEta, type KmbEtaEntry } from "@/lib/eta/kmb
 import { promisePool } from "@/lib/eta/promise-pool";
 import { kmbStopEtaCache } from "@/lib/eta/cache";
 
+export const runtime = "nodejs";
+
 const BodySchema = z.object({
   stopIds: z.array(z.string().trim().min(1)).min(1).max(100),
   routeFilter: z.string().optional(),

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-virtual": "^3.13.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -319,6 +320,10 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.18", "", { "os": "win32", "cpu": "x64" }, "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.18", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "postcss": "^8.4.41", "tailwindcss": "4.1.18" } }, "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.18", "", { "dependencies": { "@tanstack/virtual-core": "3.13.18" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.18", "", {}, "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/components/eta/favorites.tsx
+++ b/components/eta/favorites.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import * as React from "react";
+
 import { Heart, History, Trash2 } from "lucide-react";
+
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,13 +13,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LRT_STATIONS } from "@/lib/data/lrt-stations";
 import { findMtrStationBySta } from "@/lib/data/mtr-stations";
 import { getLineColor } from "@/lib/eta/line-colors";
-import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
+import { createParseKmbStopNameCached } from "@/lib/eta/kmb-stop-name";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
 import { useAppStore, type FavoritesItem } from "@/lib/store";
 
 type Props = {
   lang: UiLanguage;
   kmbStops?: KmbStopSearchItem[];
+  kmbStopById?: Map<string, KmbStopSearchItem>;
   onSelect: (item: FavoritesItem) => void;
 };
 
@@ -33,10 +38,14 @@ function FavoriteItemDisplay({
   item,
   lang,
   kmbStops,
+  kmbStopById,
+  parseKmbStopNameCached,
 }: {
   item: FavoritesItem;
   lang: UiLanguage;
   kmbStops?: KmbStopSearchItem[];
+  kmbStopById?: Map<string, KmbStopSearchItem>;
+  parseKmbStopNameCached: (fullName: string) => { name: string };
 }) {
   if (item.mode === "mtr") {
     const station = findMtrStationBySta(item.sta);
@@ -78,11 +87,11 @@ function FavoriteItemDisplay({
 
     // Single stop
     if ("stopId" in item) {
-      const stop = kmbStops?.find((s) => s.stopId === item.stopId);
+      const stop = kmbStopById?.get(item.stopId) ?? kmbStops?.find((s) => s.stopId === item.stopId);
       if (stop) {
         const fullName = pickKmbStopTitle(stop, lang);
-        const { name } = parseKmbStopName(fullName);
-        
+        const { name } = parseKmbStopNameCached(fullName);
+
         // Build suffix from saved data
         let suffix = "";
         if (item.routeFilterMode === "advanced" && item.entries?.length) {
@@ -93,18 +102,27 @@ function FavoriteItemDisplay({
         } else if (item.route) {
           suffix = ` · ${item.route}`;
         }
-        
-        return <span className="truncate">{name}{suffix}</span>;
+
+        return (
+          <span className="truncate">
+            {name}
+            {suffix}
+          </span>
+        );
       }
     }
 
     // Grouped stops
     if ("stopIds" in item) {
-      const firstStop = kmbStops?.find((s) => item.stopIds.includes(s.stopId));
+      const firstStopId = item.stopIds[0];
+      const firstStop = firstStopId
+        ? kmbStopById?.get(firstStopId) ?? kmbStops?.find((s) => item.stopIds.includes(s.stopId))
+        : undefined;
+
       if (firstStop) {
         const fullName = pickKmbStopTitle(firstStop, lang);
-        const { name } = parseKmbStopName(fullName);
-        
+        const { name } = parseKmbStopNameCached(fullName);
+
         // Build suffix from saved data
         let suffix = "";
         if (item.routeFilterMode === "advanced" && item.entries?.length) {
@@ -115,8 +133,13 @@ function FavoriteItemDisplay({
         } else if (item.route) {
           suffix = ` · ${item.route}`;
         }
-        
-        return <span className="truncate">{name}{suffix}</span>;
+
+        return (
+          <span className="truncate">
+            {name}
+            {suffix}
+          </span>
+        );
       }
     }
 
@@ -126,9 +149,28 @@ function FavoriteItemDisplay({
   return <span className="truncate">{item.title}</span>;
 }
 
-export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
+export function FavoritesAndRecents({ lang, kmbStops, kmbStopById, onSelect }: Props) {
+  const parseKmbStopNameCached = React.useMemo(() => createParseKmbStopNameCached(), []);
+
   const favorites = useAppStore((s) => s.favorites);
   const recents = useAppStore((s) => s.recents);
+
+  const favoritesParentRef = React.useRef<HTMLDivElement | null>(null);
+  const recentsParentRef = React.useRef<HTMLDivElement | null>(null);
+
+  const favoritesVirtualizer = useVirtualizer({
+    count: favorites.length,
+    getScrollElement: () => favoritesParentRef.current,
+    estimateSize: () => 56,
+    overscan: 6,
+  });
+
+  const recentsVirtualizer = useVirtualizer({
+    count: recents.length,
+    getScrollElement: () => recentsParentRef.current,
+    estimateSize: () => 56,
+    overscan: 6,
+  });
   const removeFavorite = useAppStore((s) => s.removeFavorite);
   const clearRecents = useAppStore((s) => s.clearRecents);
 
@@ -159,36 +201,53 @@ export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
 
         <CardContent className="p-0">
           <TabsContent value="favorites" className="mt-0 p-6 pt-0">
-            <div className="space-y-2">
+            <div ref={favoritesParentRef} className="max-h-[60dvh] overflow-auto">
               {favorites.length === 0 ? (
                 <div className="text-sm text-muted-foreground">{t.noFavorites}</div>
               ) : (
-                favorites.map((f) => (
-                  <div
-                    key={f.id}
-                    className="ui-animate-in-fast ui-lift flex items-center justify-between gap-2 rounded-2xl border bg-background/40 px-3 py-2"
-                  >
-                    <button
-                      className="min-w-0 flex-1 text-left"
-                      onClick={() => onSelect(f)}
-                    >
-                      <div className="text-sm font-medium">
-                        <FavoriteItemDisplay item={f} lang={lang} kmbStops={kmbStops} />
+                <div
+                  className="relative"
+                  style={{ height: `${favoritesVirtualizer.getTotalSize()}px` }}
+                >
+                  {favoritesVirtualizer.getVirtualItems().map((row) => {
+                    const f = favorites[row.index];
+                    return (
+                      <div
+                        key={f.id}
+                        className="absolute left-0 top-0 w-full px-0"
+                        style={{ transform: `translateY(${row.start}px)` }}
+                      >
+                        <div className="ui-animate-in-fast ui-lift flex items-center justify-between gap-2 rounded-2xl border bg-background/40 px-3 py-2">
+                          <button
+                            className="min-w-0 flex-1 text-left"
+                            onClick={() => onSelect(f)}
+                          >
+                            <div className="text-sm font-medium">
+                              <FavoriteItemDisplay
+                                item={f}
+                                lang={lang}
+                                kmbStops={kmbStops}
+                                kmbStopById={kmbStopById}
+                                parseKmbStopNameCached={parseKmbStopNameCached}
+                              />
+                            </div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {f.mode.toUpperCase()}
+                            </div>
+                          </button>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="rounded-xl"
+                            onClick={() => removeFavorite(f.id)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
                       </div>
-                      <div className="truncate text-xs text-muted-foreground">
-                        {f.mode.toUpperCase()}
-                      </div>
-                    </button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="rounded-xl"
-                      onClick={() => removeFavorite(f.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))
+                    );
+                  })}
+                </div>
               )}
             </div>
           </TabsContent>
@@ -196,9 +255,7 @@ export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
           <TabsContent value="recent" className="mt-0 p-6 pt-0">
             <div className="space-y-2">
               <div className="flex items-center justify-between gap-2">
-                <div className="text-xs text-muted-foreground">
-                  {t.tip}
-                </div>
+                <div className="text-xs text-muted-foreground">{t.tip}</div>
                 <Button
                   variant="ghost"
                   size="sm"
@@ -210,25 +267,46 @@ export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
                 </Button>
               </div>
 
-              {recents.length === 0 ? (
-                <div className="text-sm text-muted-foreground">{t.noRecent}</div>
-              ) : (
-                recents.map((r) => (
-                  <button
-                    key={`${r.id}-${r.at}`}
-                    className="ui-animate-in-fast ui-lift w-full rounded-2xl border bg-background/40 px-3 py-2 text-left hover:bg-background/60"
-                    onClick={() => onSelect(r)}
+              <div ref={recentsParentRef} className="max-h-[60dvh] overflow-auto">
+                {recents.length === 0 ? (
+                  <div className="text-sm text-muted-foreground">{t.noRecent}</div>
+                ) : (
+                  <div
+                    className="relative"
+                    style={{ height: `${recentsVirtualizer.getTotalSize()}px` }}
                   >
-                     <div className="text-sm font-medium">
-                       <FavoriteItemDisplay item={r} lang={lang} kmbStops={kmbStops} />
-                     </div>
-                    <div className="mt-0.5 flex items-center justify-between gap-2 text-xs text-muted-foreground">
-                      <span>{r.mode.toUpperCase()}</span>
-                      <span>{new Date(r.at).toLocaleString()}</span>
-                    </div>
-                  </button>
-                ))
-              )}
+                    {recentsVirtualizer.getVirtualItems().map((row) => {
+                      const r = recents[row.index];
+                      return (
+                        <div
+                          key={`${r.id}-${r.at}`}
+                          className="absolute left-0 top-0 w-full"
+                          style={{ transform: `translateY(${row.start}px)` }}
+                        >
+                          <button
+                            className="ui-animate-in-fast ui-lift w-full rounded-2xl border bg-background/40 px-3 py-2 text-left hover:bg-background/60"
+                            onClick={() => onSelect(r)}
+                          >
+                            <div className="text-sm font-medium">
+                              <FavoriteItemDisplay
+                                item={r}
+                                lang={lang}
+                                kmbStops={kmbStops}
+                                kmbStopById={kmbStopById}
+                                parseKmbStopNameCached={parseKmbStopNameCached}
+                              />
+                            </div>
+                            <div className="mt-0.5 flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                              <span>{r.mode.toUpperCase()}</span>
+                              <span>{new Date(r.at).toLocaleString()}</span>
+                            </div>
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             </div>
 
             <Separator className="my-2" />

--- a/components/eta/stop-search.tsx
+++ b/components/eta/stop-search.tsx
@@ -15,7 +15,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
-import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
+import { createParseKmbStopNameCached } from "@/lib/eta/kmb-stop-name";
 import { cn } from "@/lib/utils";
 
 export type StopSearchSelection =
@@ -26,6 +26,7 @@ export type StopSearchSelection =
 type Props = {
   lang: UiLanguage;
   stops: KmbStopSearchItem[];
+  stopById?: Map<string, KmbStopSearchItem>;
   value?: StopSearchSelection;
   onSelectStop: (stop: KmbStopSearchItem) => void;
   onSelectStops: (stops: KmbStopSearchItem[]) => void;
@@ -98,10 +99,16 @@ type StopGroup = {
   id: string; // Unique key for React
   baseName: string;
   codes: string[];
-  stops: KmbStopSearchItem[];
+  stopIds: string[];
   displayName: string;
   displayCodes: string;
   displaySecondary: string;
+};
+
+type StopMeta = {
+  baseName: string;
+  stopCode: string | null;
+  secondaryLabel: string;
 };
 
 /**
@@ -109,118 +116,131 @@ type StopGroup = {
  * Handles multiple separate sequential sets (e.g., KT313-KT316 AND KT681-KT683).
  * Non-sequential stops remain as individual items.
  */
-function groupStopsByName(stops: KmbStopSearchItem[], lang: UiLanguage): StopGroup[] {
-  // First, parse all stops and group by base name
-  const byBaseName = new Map<
-    string,
-    { code: string | null; stop: KmbStopSearchItem }[]
-  >();
+function createStopMetaIndex(stops: KmbStopSearchItem[], lang: UiLanguage) {
+  const parseCached = createParseKmbStopNameCached();
+
+  const stopMetaById = new Map<string, StopMeta>();
+  const stopIdsByBaseName = new Map<string, string[]>();
 
   for (const stop of stops) {
     const fullName = formatStopName(stop, lang);
-    const parsed = parseKmbStopName(fullName);
-    const baseName = parsed.name;
-    const code = parsed.stopCode;
+    const parsed = parseCached(fullName);
 
-    if (!byBaseName.has(baseName)) {
-      byBaseName.set(baseName, []);
+    const meta: StopMeta = {
+      baseName: parsed.name,
+      stopCode: parsed.stopCode,
+      secondaryLabel: formatStopSecondary(stop, lang),
+    };
+
+    stopMetaById.set(stop.stopId, meta);
+
+    const list = stopIdsByBaseName.get(meta.baseName);
+    if (list) {
+      list.push(stop.stopId);
+    } else {
+      stopIdsByBaseName.set(meta.baseName, [stop.stopId]);
     }
-    byBaseName.get(baseName)!.push({ code, stop });
   }
 
-  const result: StopGroup[] = [];
+  return { parseCached, stopMetaById, stopIdsByBaseName };
+}
 
-  for (const [baseName, items] of byBaseName) {
-    // Separate items with valid codes from those without
-    const withCodes = items.filter((i) => i.code !== null);
-    const withoutCodes = items.filter((i) => i.code === null);
+function buildGroupsByBaseName(
+  stopIdsByBaseName: Map<string, string[]>,
+  stopMetaById: Map<string, StopMeta>
+) {
+  const groupsByBaseName = new Map<string, StopGroup[]>();
 
-    // Sort by code prefix then number
+  for (const [baseName, stopIds] of stopIdsByBaseName) {
+    const items = stopIds.map((stopId) => ({ stopId, meta: stopMetaById.get(stopId)! }));
+
+    const withCodes = items.filter((i) => i.meta.stopCode !== null);
+    const withoutCodes = items.filter((i) => i.meta.stopCode === null);
+
     withCodes.sort((a, b) => {
-      const pa = parseCodeParts(a.code!);
-      const pb = parseCodeParts(b.code!);
+      const pa = parseCodeParts(a.meta.stopCode!);
+      const pb = parseCodeParts(b.meta.stopCode!);
       if (!pa || !pb) return 0;
       if (pa.prefix !== pb.prefix) return pa.prefix.localeCompare(pb.prefix);
       return pa.num - pb.num;
     });
 
-    // Find contiguous runs of sequential codes
-    const runs: { code: string; stop: KmbStopSearchItem }[][] = [];
+    const runs: { stopId: string; meta: StopMeta }[][] = [];
     for (const item of withCodes) {
-      // We know code is non-null because we filtered above
-      const typedItem = item as { code: string; stop: KmbStopSearchItem };
       const lastRun = runs[runs.length - 1];
       if (!lastRun) {
-        runs.push([typedItem]);
+        runs.push([item]);
         continue;
       }
-      const lastItem = lastRun[lastRun.length - 1];
-      const lastParts = parseCodeParts(lastItem.code);
-      const currParts = parseCodeParts(typedItem.code);
 
-      // Check if sequential (same prefix, consecutive number)
+      const lastItem = lastRun[lastRun.length - 1];
+      const lastParts = parseCodeParts(lastItem.meta.stopCode!);
+      const currParts = parseCodeParts(item.meta.stopCode!);
+
       if (
         lastParts &&
         currParts &&
         lastParts.prefix === currParts.prefix &&
         currParts.num === lastParts.num + 1
       ) {
-        lastRun.push(typedItem);
+        lastRun.push(item);
       } else {
-        runs.push([typedItem]);
+        runs.push([item]);
       }
     }
 
-    // Create groups from runs
+    const groups: StopGroup[] = [];
+
     for (const run of runs) {
       if (run.length >= 2) {
-        // Create a grouped suggestion for 2+ sequential stops
-        const codes = run.map((r) => r.code!);
-        const runStops = run.map((r) => r.stop);
-        result.push({
-          id: `group:${runStops.map((s) => s.stopId).join(",")}`,
+        const codes = run.map((r) => r.meta.stopCode!).filter(Boolean);
+        const stopIdsForRun = run.map((r) => r.stopId);
+
+        groups.push({
+          id: `group:${stopIdsForRun.join(",")}`,
           baseName,
           codes,
-          stops: runStops,
+          stopIds: stopIdsForRun,
           displayName: baseName,
           displayCodes: `(${formatCodeRange(codes)})`,
-          displaySecondary: formatStopSecondary(runStops[0], lang),
+          displaySecondary: run[0].meta.secondaryLabel,
         });
       } else {
-        // Single item in run - add as individual
         const item = run[0];
-        result.push({
-          id: `stop:${item.stop.stopId}`,
+        groups.push({
+          id: `stop:${item.stopId}`,
           baseName,
-          codes: [item.code!],
-          stops: [item.stop],
+          codes: [item.meta.stopCode!],
+          stopIds: [item.stopId],
           displayName: baseName,
-          displayCodes: `(${item.code})`,
-          displaySecondary: formatStopSecondary(item.stop, lang),
+          displayCodes: `(${item.meta.stopCode})`,
+          displaySecondary: item.meta.secondaryLabel,
         });
       }
     }
 
-    // Add items without codes as individuals
     for (const item of withoutCodes) {
-      result.push({
-        id: `stop:${item.stop.stopId}`,
+      groups.push({
+        id: `stop:${item.stopId}`,
         baseName,
         codes: [],
-        stops: [item.stop],
+        stopIds: [item.stopId],
         displayName: baseName,
         displayCodes: "",
-        displaySecondary: formatStopSecondary(item.stop, lang),
+        displaySecondary: item.meta.secondaryLabel,
       });
     }
+
+    groupsByBaseName.set(baseName, groups);
   }
 
-  return result;
+  return groupsByBaseName;
 }
 
 export function StopSearch({
   lang,
   stops,
+  stopById: stopByIdProp,
   value,
   onSelectStop,
   onSelectStops,
@@ -233,46 +253,57 @@ export function StopSearch({
   const deferredQuery = React.useDeferredValue(query);
   const isSearching = query !== deferredQuery;
 
+  const stopById = React.useMemo(() => {
+    if (stopByIdProp) return stopByIdProp;
+    return new Map(stops.map((s) => [s.stopId, s] as const));
+  }, [stopByIdProp, stops]);
+
+  const { parseCached, stopMetaById, stopIdsByBaseName } = React.useMemo(
+    () => createStopMetaIndex(stops, lang),
+    [stops, lang]
+  );
+
+  const groupsByBaseName = React.useMemo(
+    () => buildGroupsByBaseName(stopIdsByBaseName, stopMetaById),
+    [stopIdsByBaseName, stopMetaById]
+  );
+
   // Find selected stop(s) for display in the button
   const selectedLabel = React.useMemo(() => {
     if (!value) return null;
+
     if (value.type === "stop") {
-      const stop = stops.find((s) => s.stopId === value.stopId);
-      if (stop) {
-        const fullName = formatStopName(stop, lang);
-        const parsed = parseKmbStopName(fullName);
-        return parsed.stopCode ? `${parsed.name} (${parsed.stopCode})` : parsed.name;
-      }
-      return null;
+      const stop = stopById.get(value.stopId);
+      if (!stop) return null;
+
+      const fullName = formatStopName(stop, lang);
+      const parsed = parseCached(fullName);
+      return parsed.stopCode ? `${parsed.name} (${parsed.stopCode})` : parsed.name;
     }
+
     if (value.type === "stops") {
-      // Find first stop to get base name
-      const firstStop = stops.find((s) => value.stopIds.includes(s.stopId));
-      if (!firstStop) return null;
+      const baseName = stopMetaById.get(value.stopIds[0])?.baseName;
+      if (!baseName) return null;
 
-      const fullName = formatStopName(firstStop, lang);
-      const { name: baseName } = parseKmbStopName(fullName);
-
-      // Collect all codes for selected stops
       const codes: string[] = [];
       for (const stopId of value.stopIds) {
-        const stop = stops.find((s) => s.stopId === stopId);
-        if (stop) {
-          const parsed = parseKmbStopName(formatStopName(stop, lang));
-          if (parsed.stopCode) codes.push(parsed.stopCode);
-        }
+        const code = stopMetaById.get(stopId)?.stopCode;
+        if (code) codes.push(code);
       }
 
       if (codes.length > 1 && areCodesSequential(codes)) {
         return `${baseName} (${formatCodeRange(codes)})`;
       }
+
       return baseName;
     }
+
     if (value.type === "contains") {
       return (lang === "en" ? "Contains: " : lang === "sc" ? "包含: " : "包含: ") + value.query;
     }
+
     return null;
-  }, [value, stops, lang]);
+  }, [value, stopById, stopMetaById, lang, parseCached]);
 
 
   // Use Fuse.js to search individual stops, then group results
@@ -293,22 +324,59 @@ export function StopSearch({
   const groupedResults = React.useMemo(() => {
     if (!deferredQuery.trim()) {
       // Default: show first 12 stops, grouped
-      return groupStopsByName(stops.slice(0, 30), lang).slice(0, 12);
+      const baseNames = new Set<string>();
+      const groups: StopGroup[] = [];
+
+      for (const stop of stops.slice(0, 30)) {
+        const baseName = stopMetaById.get(stop.stopId)?.baseName;
+        if (!baseName || baseNames.has(baseName)) continue;
+
+        const groupsForName = groupsByBaseName.get(baseName);
+        if (!groupsForName) continue;
+
+        baseNames.add(baseName);
+        groups.push(...groupsForName);
+        if (groups.length >= 12) break;
+      }
+
+      return groups.slice(0, 12);
     }
+
     const hits = fuse.search(deferredQuery.trim()).slice(0, 60);
-    const matchedStops = hits.map((h) => h.item);
-    return groupStopsByName(matchedStops, lang).slice(0, 20);
-  }, [fuse, deferredQuery, stops, lang]);
+
+    const baseNames = new Set<string>();
+    const groups: StopGroup[] = [];
+
+    for (const hit of hits) {
+      const stopId = hit.item.stopId;
+      const baseName = stopMetaById.get(stopId)?.baseName;
+      if (!baseName || baseNames.has(baseName)) continue;
+
+      const groupsForName = groupsByBaseName.get(baseName);
+      if (!groupsForName) continue;
+
+      baseNames.add(baseName);
+      groups.push(...groupsForName);
+      if (groups.length >= 20) break;
+    }
+
+    return groups.slice(0, 20);
+  }, [fuse, deferredQuery, stops, stopMetaById, groupsByBaseName]);
 
   const trimmedQuery = query.trim();
   const canSearchContains = trimmedQuery.length >= 3;
 
   const handleSelectGroup = (group: StopGroup) => {
-    if (group.stops.length === 1) {
-      onSelectStop(group.stops[0]);
+    const selectedStops = group.stopIds
+      .map((stopId) => stopById.get(stopId))
+      .filter(Boolean) as KmbStopSearchItem[];
+
+    if (selectedStops.length === 1) {
+      onSelectStop(selectedStops[0]);
     } else {
-      onSelectStops(group.stops);
+      onSelectStops(selectedStops);
     }
+
     setOpen(false);
   };
 

--- a/lib/eta/cache.ts
+++ b/lib/eta/cache.ts
@@ -138,3 +138,7 @@ export class MicroCache<T> {
 export const kmbStopEtaCache = new MicroCache<unknown>({ ttlMs: 15_000, maxSize: 500 });
 export const mtrScheduleCache = new MicroCache<unknown>({ ttlMs: 12_000, maxSize: 200 });
 export const lrtScheduleCache = new MicroCache<unknown>({ ttlMs: 12_000, maxSize: 100 });
+
+// KMB static datasets can be large (e.g. route-stop > 2MB), which cannot be stored
+// in Next.js' Data Cache on Vercel. Cache it in-memory per instance instead.
+export const kmbRouteStopCache = new MicroCache<unknown>({ ttlMs: 60 * 60 * 1000, maxSize: 5 });

--- a/lib/eta/kmb-stop-name.ts
+++ b/lib/eta/kmb-stop-name.ts
@@ -4,6 +4,21 @@ export type ParsedKmbStopName = {
   platform: string | null;
 };
 
+export type ParseKmbStopNameFn = (fullName: string) => ParsedKmbStopName;
+
+export function createParseKmbStopNameCached(): ParseKmbStopNameFn {
+  const cache = new Map<string, ParsedKmbStopName>();
+
+  return (fullName: string) => {
+    const cached = cache.get(fullName);
+    if (cached) return cached;
+
+    const parsed = parseKmbStopName(fullName);
+    cache.set(fullName, parsed);
+    return parsed;
+  };
+}
+
 // Platform: 1 letter + 1–2 digits (e.g. A12)
 const PLATFORM_RE = "[A-Z][0-9]{1,2}";
 

--- a/lib/eta/kmb.ts
+++ b/lib/eta/kmb.ts
@@ -1,3 +1,4 @@
+import { kmbRouteStopCache } from "@/lib/eta/cache";
 import { secondsUntilNextKmbDailyUpdate } from "@/lib/eta/kmb-cache";
 import { fetchJson } from "@/lib/eta/http";
 
@@ -89,14 +90,22 @@ export type KmbRouteStopEntry = {
 };
 
 export async function getKmbRouteStops(): Promise<KmbRouteStopEntry[]> {
+  // The route-stop payload is >2MB, so Next.js Data Cache can't store it on Vercel.
+  // Cache it in-memory per instance until the next daily update.
+  const ttlMs = secondsUntilNextKmbDailyUpdate() * 1000;
+
+  const cached = kmbRouteStopCache.get("kmb:route-stop") as KmbRouteStopEntry[] | undefined;
+  if (cached !== undefined) return cached;
+
   const json = await fetchJson<KmbApiEnvelope<KmbRouteStopEntry[]>>(
     `${KMB_BASE_URL}/v1/transport/kmb/route-stop`,
     {
-      next: {
-        revalidate: secondsUntilNextKmbDailyUpdate(),
-      },
+      cache: "no-store",
+      timeoutMs: 20_000,
     }
   );
+
+  kmbRouteStopCache.set("kmb:route-stop", json.data, ttlMs);
   return json.data;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-virtual": "^3.13.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -32,7 +33,7 @@
         "react-dom": "19.2.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
-        "zod": "^4.2.1",
+        "zod": "^3.23.0",
         "zustand": "^5.0.9"
       },
       "devDependencies": {
@@ -2574,6 +2575,33 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz",
+      "integrity": "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz",
+      "integrity": "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -7862,9 +7890,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-virtual": "^3.13.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary
- Cache KMB stop-name parsing to avoid repeated regex work.
- Precompute stop grouping metadata so typing only runs Fuse search + O(1) lookups.
- Virtualize Saved (favorites/recents) lists to keep sheet open/snappy with many items.

## Notes
- 
> timoeta@0.1.0 lint
> eslint


/home/timo/Documents/GitHub/eta/components/eta/favorites.tsx
  161:32  warning  Compilation Skipped: Use of incompatible library

This API returns functions which cannot be memoized without leading to stale UI. To prevent this, by default React Compiler will skip memoizing this component/hook. However, you may see issues if values from this API are passed to other components/hooks that are memoized.

/home/timo/Documents/GitHub/eta/components/eta/favorites.tsx:161:32
  159 |   const recentsParentRef = React.useRef<HTMLDivElement | null>(null);
  160 |
> 161 |   const favoritesVirtualizer = useVirtualizer({
      |                                ^^^^^^^^^^^^^^ TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely
  162 |     count: favorites.length,
  163 |     getScrollElement: () => favoritesParentRef.current,
  164 |     estimateSize: () => 56,  react-hooks/incompatible-library

/home/timo/Documents/GitHub/eta/components/eta/results-kmb.tsx
  256:9  warning  'fareLoading' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/timo/Documents/GitHub/eta/lib/eta/use-mtr-schedule.ts
  59:21  warning  'key' is assigned a value but never used  @typescript-eslint/no-unused-vars

✖ 3 problems (0 errors, 3 warnings) still has existing warnings; build succeeds.
- React Compiler warns about  incompatibility (expected for TanStack Virtual).