### PR TITLE
Improve refresh timing and search UX

### DIFF
--- a/components/eta/lrt-stop-search.tsx
+++ b/components/eta/lrt-stop-search.tsx
@@ -95,7 +95,7 @@ export function LrtStationSearch({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          aria-controls={listId}
+          aria-controls={open ? listId : undefined}
           aria-haspopup="listbox"
           className={cn(
             "w-full justify-start rounded-2xl border bg-card/70 text-left shadow-sm",

--- a/components/eta/lrt-stop-search.tsx
+++ b/components/eta/lrt-stop-search.tsx
@@ -47,14 +47,19 @@ export function LrtStationSearch({
 }: Props) {
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState("");
+  const listId = React.useId();
 
   const trimmedQuery = query.trim();
   const showStationId = isStationIdQuery(trimmedQuery);
 
-  const selected = React.useMemo(
-    () => stations.find((s) => s.stationId === selectedStationId),
-    [stations, selectedStationId]
-  );
+  const stationsById = React.useMemo(() => {
+    return new Map(stations.map((station) => [station.stationId, station]));
+  }, [stations]);
+
+  const selected = React.useMemo(() => {
+    if (!selectedStationId) return undefined;
+    return stationsById.get(selectedStationId);
+  }, [selectedStationId, stationsById]);
 
   const fuse = React.useMemo(() => {
     return new Fuse(stations, {
@@ -78,8 +83,10 @@ export function LrtStationSearch({
     }
 
     const hits = fuse.search(trimmedQuery).slice(0, 40);
-    return hits.map((h) => h.item);
+    return hits.map((h: { item: LrtStationSearchItem }) => h.item);
   }, [fuse, showStationId, stations, trimmedQuery]);
+
+  const displayResults = trimmedQuery ? results : stations.slice(0, 12);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -88,6 +95,8 @@ export function LrtStationSearch({
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          aria-controls={listId}
+          aria-haspopup="listbox"
           className={cn(
             "w-full justify-start rounded-2xl border bg-card/70 text-left shadow-sm",
             "hover:bg-card",
@@ -107,10 +116,10 @@ export function LrtStationSearch({
             value={query}
             onValueChange={setQuery}
           />
-          <CommandList>
+          <CommandList id={listId}>
             <CommandEmpty>{lang === "en" ? "No results." : "無結果。"}</CommandEmpty>
             <CommandGroup heading={lang === "en" ? "Stops" : lang === "sc" ? "车站" : "車站"}>
-              {(results.length ? results : stations.slice(0, 12)).map((station) => (
+              {displayResults.map((station: LrtStationSearchItem) => (
                 <CommandItem
                   key={station.stationId}
                   value={station.stationId}

--- a/components/eta/station-search.tsx
+++ b/components/eta/station-search.tsx
@@ -42,14 +42,19 @@ function isStationCodeQuery(query: string) {
 export function MtrStationSearch({ lang, stations, selectedSta, onSelect }: Props) {
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState("");
+  const listId = React.useId();
 
   const trimmedQuery = query.trim();
   const showStationCode = isStationCodeQuery(trimmedQuery);
 
+  const stationsById = React.useMemo(() => {
+    return new Map(stations.map((station) => [station.sta, station]));
+  }, [stations]);
+
   const selectedStation = React.useMemo(() => {
     if (!selectedSta) return undefined;
-    return stations.find((s) => s.sta === selectedSta);
-  }, [stations, selectedSta]);
+    return stationsById.get(selectedSta);
+  }, [selectedSta, stationsById]);
 
   const fuse = React.useMemo(() => {
     return new Fuse(stations, {
@@ -73,8 +78,10 @@ export function MtrStationSearch({ lang, stations, selectedSta, onSelect }: Prop
     }
 
     const hits = fuse.search(trimmedQuery).slice(0, 40);
-    return hits.map((h) => h.item);
+    return hits.map((h: { item: MtrStationSearchItem }) => h.item);
   }, [fuse, showStationCode, stations, trimmedQuery]);
+
+  const displayResults = trimmedQuery ? results : stations.slice(0, 12);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -83,6 +90,8 @@ export function MtrStationSearch({ lang, stations, selectedSta, onSelect }: Prop
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          aria-controls={listId}
+          aria-haspopup="listbox"
           className={cn(
             "w-full justify-start rounded-2xl border bg-card/70 text-left shadow-sm",
             "hover:bg-card",
@@ -102,10 +111,10 @@ export function MtrStationSearch({ lang, stations, selectedSta, onSelect }: Prop
             value={query}
             onValueChange={setQuery}
           />
-          <CommandList>
+          <CommandList id={listId}>
             <CommandEmpty>{lang === "en" ? "No results." : "無結果。"}</CommandEmpty>
             <CommandGroup heading={lang === "en" ? "Stations" : lang === "sc" ? "车站" : "車站"}>
-              {(results.length ? results : stations.slice(0, 12)).map((station) => (
+              {displayResults.map((station: MtrStationSearchItem) => (
                 <CommandItem
                   key={station.labelId}
                   value={station.labelId}

--- a/components/eta/station-search.tsx
+++ b/components/eta/station-search.tsx
@@ -90,7 +90,7 @@ export function MtrStationSearch({ lang, stations, selectedSta, onSelect }: Prop
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          aria-controls={listId}
+          aria-controls={open ? listId : undefined}
           aria-haspopup="listbox"
           className={cn(
             "w-full justify-start rounded-2xl border bg-card/70 text-left shadow-sm",

--- a/components/eta/stop-search.tsx
+++ b/components/eta/stop-search.tsx
@@ -406,7 +406,7 @@ export function StopSearch({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          aria-controls={listId}
+          aria-controls={open ? listId : undefined}
           aria-haspopup="listbox"
           className={cn(
             "w-full min-w-0 justify-start rounded-2xl border bg-card/70 text-left shadow-sm",

--- a/components/eta/stop-search.tsx
+++ b/components/eta/stop-search.tsx
@@ -230,16 +230,21 @@ export function StopSearch({
 }: Props) {
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState("");
+  const listId = React.useId();
 
   // Defer the search query to keep input responsive during typing
   const deferredQuery = React.useDeferredValue(query);
   const isSearching = query !== deferredQuery;
 
+  const stopById = React.useMemo(() => {
+    return new Map(stops.map((stop) => [stop.stopId, stop]));
+  }, [stops]);
+
   // Find selected stop(s) for display in the button
   const selectedLabel = React.useMemo(() => {
     if (!value) return null;
     if (value.type === "stop") {
-      const stop = stops.find((s) => s.stopId === value.stopId);
+      const stop = stopById.get(value.stopId);
       if (stop) {
         const fullName = formatStopName(stop, lang);
         const parsed = parseKmbStopName(fullName);
@@ -249,7 +254,7 @@ export function StopSearch({
     }
     if (value.type === "stops") {
       // Find first stop to get base name
-      const firstStop = stops.find((s) => value.stopIds.includes(s.stopId));
+      const firstStop = value.stopIds.map((stopId) => stopById.get(stopId)).find(Boolean);
       if (!firstStop) return null;
 
       const fullName = formatStopName(firstStop, lang);
@@ -258,7 +263,7 @@ export function StopSearch({
       // Collect all codes for selected stops
       const codes: string[] = [];
       for (const stopId of value.stopIds) {
-        const stop = stops.find((s) => s.stopId === stopId);
+        const stop = stopById.get(stopId);
         if (stop) {
           const parsed = parseKmbStopName(formatStopName(stop, lang));
           if (parsed.stopCode) codes.push(parsed.stopCode);
@@ -274,7 +279,7 @@ export function StopSearch({
       return (lang === "en" ? "Contains: " : lang === "sc" ? "包含: " : "包含: ") + value.query;
     }
     return null;
-  }, [value, stops, lang]);
+  }, [value, stopById, lang]);
 
 
   const stopComputed = React.useMemo<StopComputed[]>(() => {
@@ -342,8 +347,14 @@ export function StopSearch({
     // This improves accuracy for common user behavior:
     // - typing stop code prefixes (KT31…)
     // - typing station name prefixes
+    type ScoredStop = {
+      item: StopComputed;
+      fuseScore: number;
+      boost: number;
+    };
+
     const scored = hits
-      .map((h: { item: StopComputed; score?: number }) => {
+      .map((h: { item: StopComputed; score?: number }): ScoredStop => {
         const item = h.item;
 
         const exact =
@@ -367,26 +378,26 @@ export function StopSearch({
         const boost = exact ? 0 : prefix ? 1 : includes ? 2 : 3;
         return { item, fuseScore, boost };
       })
-      .sort((a, b) => {
+      .sort((a: ScoredStop, b: ScoredStop) => {
         if (a.boost !== b.boost) return a.boost - b.boost;
         return a.fuseScore - b.fuseScore;
       })
       .slice(0, 60);
 
-    return groupStopsByName(scored.map((s) => s.item)).slice(0, 20);
+    return groupStopsByName(scored.map((s: ScoredStop) => s.item)).slice(0, 20);
   }, [fuse, deferredQuery, stopComputed]);
 
   const trimmedQuery = query.trim();
   const canSearchContains = trimmedQuery.length >= 3;
 
-  const handleSelectGroup = (group: StopGroup) => {
+  const handleSelectGroup = React.useCallback((group: StopGroup) => {
     if (group.stops.length === 1) {
       onSelectStop(group.stops[0]);
     } else {
       onSelectStops(group.stops);
     }
     setOpen(false);
-  };
+  }, [onSelectStop, onSelectStops]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -395,6 +406,8 @@ export function StopSearch({
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          aria-controls={listId}
+          aria-haspopup="listbox"
           className={cn(
             "w-full min-w-0 justify-start rounded-2xl border bg-card/70 text-left shadow-sm",
             "hover:bg-card",
@@ -414,7 +427,10 @@ export function StopSearch({
             value={query}
             onValueChange={setQuery}
           />
-          <CommandList className={cn(isSearching && "opacity-60 transition-opacity")}>
+          <CommandList
+            id={listId}
+            className={cn(isSearching && "opacity-60 transition-opacity")}
+          >
             <CommandEmpty>{lang === "en" ? "No results." : "無結果。"}</CommandEmpty>
             <CommandGroup heading={lang === "en" ? "Stops" : lang === "sc" ? "车站" : "車站"}>
               {canSearchContains ? (

--- a/lib/eta/client.ts
+++ b/lib/eta/client.ts
@@ -117,12 +117,12 @@ export async function fetchKmbEtas(plans: Array<{ stopId: string; route: string;
   const eta: KmbEtaEntry[] = [];
   const errors: Array<{ stopId: string; route: string; serviceType: string }> = [];
 
-  for (const result of results) {
+  for (let i = 0; i < results.length; i += 1) {
+    const result = results[i];
     if (result.status === "fulfilled") {
       eta.push(...result.value.eta);
     } else {
-      const index = results.indexOf(result);
-      const plan = plans[index];
+      const plan = plans[i];
       if (plan) errors.push(plan);
     }
   }

--- a/lib/eta/direct/kmb.ts
+++ b/lib/eta/direct/kmb.ts
@@ -331,11 +331,12 @@ export async function fetchKmbStopEtas(
     return { stopId, eta: cachedValue.value };
   });
 
-  for (const result of results) {
+  for (let i = 0; i < results.length; i += 1) {
+    const result = results[i];
     if (result.status === "rejected") {
-      const idx = results.indexOf(result);
-      if (idx >= 0 && uniqueStopIds[idx]) {
-        errors.push(uniqueStopIds[idx]);
+      const stopId = uniqueStopIds[i];
+      if (stopId) {
+        errors.push(stopId);
       }
       continue;
     }

--- a/lib/eta/use-auto-refresh.ts
+++ b/lib/eta/use-auto-refresh.ts
@@ -15,15 +15,21 @@ export function useAutoRefresh(refreshMs: number, refresh: () => void) {
   React.useEffect(() => {
     if (!refreshMs) return;
 
-    let interval: ReturnType<typeof setInterval> | undefined;
     let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    let lastRefreshTime = Date.now();
+
+    const refreshWithTimestamp = () => {
+      refresh();
+      lastRefreshTime = Date.now();
+    };
 
     const scheduleNext = () => {
       // Add jitter to each interval to prevent synchronized refreshes
       const nextMs = addJitter(refreshMs);
       timeout = setTimeout(() => {
         if (document.visibilityState === "visible") {
-          refresh();
+          refreshWithTimestamp();
         }
         scheduleNext();
       }, nextMs);
@@ -33,14 +39,12 @@ export function useAutoRefresh(refreshMs: number, refresh: () => void) {
 
     // Handle visibility change - refresh immediately when tab becomes visible
     // but only if enough time has passed since last refresh
-    let lastRefreshTime = Date.now();
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         const elapsed = Date.now() - lastRefreshTime;
         // Only refresh if at least 30% of the interval has passed
         if (elapsed > refreshMs * 0.3) {
-          refresh();
-          lastRefreshTime = Date.now();
+          refreshWithTimestamp();
         }
       }
     };
@@ -48,7 +52,6 @@ export function useAutoRefresh(refreshMs: number, refresh: () => void) {
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
-      if (interval) clearInterval(interval);
       if (timeout) clearTimeout(timeout);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };


### PR DESCRIPTION
## Summary
- remove O(n^2) result indexing in KMB ETA fetch paths
- keep auto-refresh timestamps accurate for visibility-triggered refreshes
- improve search combobox accessibility and empty-result behavior

## Testing
- not run (no test suite)