### PR TITLE
Improve schedule fetch robustness

### DIFF
--- a/lib/eta/direct/lrt.ts
+++ b/lib/eta/direct/lrt.ts
@@ -97,7 +97,7 @@ async function loadLrtSchedule(stationId: string): Promise<LrtScheduleResponse> 
 
   const platformMap = new Map<number, LrtRouteEntry[]>();
 
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     variants.map(async (entry) => {
       const bound = entry.bound.lightRail ?? "";
       const stop =
@@ -136,8 +136,9 @@ async function loadLrtSchedule(stationId: string): Promise<LrtScheduleResponse> 
     })
   );
 
-  for (const entries of results) {
-    for (const entry of entries) {
+  for (const result of results) {
+    if (result.status !== "fulfilled") continue;
+    for (const entry of result.value) {
       if (!entry.platform_id) continue;
       const list = platformMap.get(entry.platform_id) ?? [];
       list.push(entry);

--- a/lib/eta/lrt.ts
+++ b/lib/eta/lrt.ts
@@ -107,7 +107,7 @@ export async function getLrtSchedule(params: {
 
   const platformMap = new Map<number, LrtRouteEntry[]>();
 
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     variants.map(async (entry) => {
       const bound = entry.bound.lightRail ?? "";
       const stop = entry.stops.lightRail?.find((id) => id.toUpperCase() === stopId.toUpperCase()) ?? stopId;
@@ -141,8 +141,9 @@ export async function getLrtSchedule(params: {
     })
   );
 
-  for (const entries of results) {
-    for (const entry of entries) {
+  for (const result of results) {
+    if (result.status !== "fulfilled") continue;
+    for (const entry of result.value) {
       if (!entry.platform_id) continue;
       const list = platformMap.get(entry.platform_id) ?? [];
       list.push(entry);

--- a/lib/eta/use-lrt-schedule.ts
+++ b/lib/eta/use-lrt-schedule.ts
@@ -23,6 +23,9 @@ export function useLrtSchedule(params: { stations: LrtStationSearchItem[]; lang:
     async (options?: { toastOnError?: boolean }) => {
       if (!stationId) return;
 
+      const station = stations.find((entry) => entry.stationId === stationId);
+      if (!station) return;
+
       // Cancel any in-flight request
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
@@ -60,7 +63,7 @@ export function useLrtSchedule(params: { stations: LrtStationSearchItem[]; lang:
         }
       }
     },
-    [stationId]
+    [stationId, stations]
   );
 
   // Cleanup abort controller on unmount

--- a/lib/eta/use-mtr-schedule.ts
+++ b/lib/eta/use-mtr-schedule.ts
@@ -63,7 +63,8 @@ export function useMtrSchedule(params: {
         }
 
         if (!baseline) {
-          setSchedule(null);
+          setError("Failed to load schedule");
+          setStale(true);
           return;
         }
 


### PR DESCRIPTION
## Summary
- tolerate partial LRT schedule failures by handling per-variant errors
- guard invalid LRT station ids before fetching
- mark MTR schedules stale when all line queries fail

## Testing
- not run (not requested)