### PR TITLE
Optimize hk-bus-eta caching and refresh

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -337,6 +337,7 @@ export default function Home() {
                   sentinelRef={kmbPaneState?.sentinelRef}
                   hasMoreStops={kmbPaneState?.hasMoreStops}
                   precomputedGroups={kmbPaneState?.precomputedGroups}
+                  registerStopRef={kmbPaneState?.registerStopRef}
                 />
 
               ) : null}

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -26,7 +26,7 @@ import {
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
 import type { Company } from "hk-bus-eta";
-import { useInfiniteScroll } from "@/lib/eta/use-infinite-scroll";
+import { useInfiniteScroll, useVisibleItems } from "@/lib/eta/use-infinite-scroll";
 import { cn } from "@/lib/utils";
 import type { FavoritesItem, RouteFilterMode } from "@/lib/store";
 
@@ -411,6 +411,10 @@ export type KmbPaneState = {
   hasMoreStops: boolean;
   /** Precomputed render groups to avoid recomputation during render */
   precomputedGroups: PrecomputedGroups;
+  /** Currently visible stop IDs in the list */
+  visibleStopIds: Set<string>;
+  /** Register ref for stop sections (visible tracking) */
+  registerStopRef?: (stopId: string) => (el: HTMLElement | null) => void;
 };
 
 export function KmbPane({
@@ -519,6 +523,11 @@ export function KmbPane({
     pageSize: STOPS_PER_PAGE,
     rootMargin: "300px",
   });
+
+  const { visibleIds: visibleStopIds, registerRef: registerStopRef } = useVisibleItems(
+    loadedStopIds,
+    { rootMargin: "200px" }
+  );
 
   // Derived flat eta array for backwards compatibility
   const kmbEta = React.useMemo(() => {
@@ -717,6 +726,8 @@ export function KmbPane({
         routeFilterString?: string;
         signal?: AbortSignal;
         append?: boolean;
+        mergeExisting?: boolean;
+        replaceLoadedStopIds?: string[];
       }
     ) => {
       if (!stopIds.length) return;
@@ -764,11 +775,15 @@ export function KmbPane({
         });
       } else {
         // Replace mode: full refresh
+        const mergedByStopId = options.mergeExisting
+          ? { ...etaState.byStopId, ...filteredByStopId }
+          : filteredByStopId;
+        const nextLoadedStopIds = options.replaceLoadedStopIds ?? stopIds;
         dispatchEta({
           type: "REFRESH_SUCCESS",
           payload: {
-            byStopId: filteredByStopId,
-            loadedStopIds: stopIds,
+            byStopId: mergedByStopId,
+            loadedStopIds: nextLoadedStopIds,
             // Keep existing fares - they'll be updated in background
           },
         });
@@ -829,7 +844,10 @@ export function KmbPane({
 
   // Main refresh function - handles both initial load and refresh of loaded stops
   const refreshKmbEta = React.useCallback(
-    async (queryOverride?: KmbQuery | null, options?: { toastOnError?: boolean; isInitialLoad?: boolean }) => {
+    async (
+      queryOverride?: KmbQuery | null,
+      options?: { toastOnError?: boolean; isInitialLoad?: boolean; isAutoRefresh?: boolean }
+    ) => {
       const query = queryOverride ?? kmbQuery;
       if (!query) return;
 
@@ -859,12 +877,28 @@ export function KmbPane({
         ? queryStopIds.slice(0, STOPS_PER_PAGE)
         : loadedStopIds;
 
+      const shouldLimitToVisible =
+        Boolean(options?.isAutoRefresh) &&
+        !isNewQuery &&
+        loadedStopIds.length > STOPS_PER_PAGE;
+
+      const visibleStopIdsList = shouldLimitToVisible
+        ? loadedStopIds.filter((stopId) => visibleStopIds.has(stopId))
+        : [];
+
+      const refreshStopIds =
+        shouldLimitToVisible && visibleStopIdsList.length > 0
+          ? visibleStopIdsList
+          : stopIdsToFetch;
+
       dispatchEta({ type: "REFRESH_START" });
       try {
-        const fetchResult = await fetchStopEtas(stopIdsToFetch, {
+        const fetchResult = await fetchStopEtas(refreshStopIds, {
           routeFilterString,
           signal: controller.signal,
           append: false, // Always replace on refresh
+          mergeExisting: shouldLimitToVisible,
+          replaceLoadedStopIds: stopIdsToFetch,
         });
 
         if (controller.signal.aborted) return;
@@ -884,7 +918,7 @@ export function KmbPane({
           );
 
           // Use index instead of filtering entire kmbRouteStops array
-          const candidateKeysFromStops = getVariantKeysForStops(routeStopIndex, stopIdsToFetch);
+          const candidateKeysFromStops = getVariantKeysForStops(routeStopIndex, refreshStopIds);
 
           const allVariantKeys = new Set([...variantKeysFromEtas, ...candidateKeysFromStops]);
           const missingKeys = Array.from(allVariantKeys).filter(
@@ -930,7 +964,16 @@ export function KmbPane({
       }
       // Note: loading state is managed by REFRESH_START/REFRESH_SUCCESS/REFRESH_ERROR
     },
-    [kmbQuery, kmbRouteInfos, loadedStopIds, getRouteFilterString, fetchStopEtas, resolveContainsStopIds, routeStopIndex]
+    [
+      kmbQuery,
+      kmbRouteInfos,
+      loadedStopIds,
+      getRouteFilterString,
+      fetchStopEtas,
+      resolveContainsStopIds,
+      routeStopIndex,
+      visibleStopIds,
+    ]
   );
 
   const loadMoreLoadingRef = React.useRef(false);
@@ -1006,7 +1049,9 @@ export function KmbPane({
 
   React.useEffect(() => {
     if (!onRegisterRefresh) return;
-    onRegisterRefresh(() => refreshKmbEtaRef.current(kmbQuery, { toastOnError: false }));
+    onRegisterRefresh(() =>
+      refreshKmbEtaRef.current(kmbQuery, { toastOnError: false, isAutoRefresh: true })
+    );
   }, [kmbQuery, onRegisterRefresh]);
 
   const lastSelectedIdRef = React.useRef<string | null>(null);
@@ -1361,6 +1406,8 @@ export function KmbPane({
       sentinelRef: infiniteScroll.sentinelRef,
       hasMoreStops: infiniteScroll.hasMore,
       precomputedGroups,
+      visibleStopIds,
+      registerStopRef,
     }),
     [
       kmbEta,
@@ -1383,6 +1430,8 @@ export function KmbPane({
       infiniteScroll.sentinelRef,
       infiniteScroll.hasMore,
       precomputedGroups,
+      visibleStopIds,
+      registerStopRef,
     ]
   );
 

--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -219,6 +219,8 @@ type Props = {
   hasMoreStops?: boolean;
   /** Precomputed render groups from pane (avoids recomputation during render) */
   precomputedGroups?: PrecomputedGroups;
+  /** Register ref for stop sections (visible tracking) */
+  registerStopRef?: (stopId: string) => (el: HTMLElement | null) => void;
 };
 
 /** Render a single route variant card */
@@ -515,6 +517,7 @@ function StopSection({
   now,
   isFirst,
   stopLookup,
+  registerStopRef,
 }: {
   stopId: string;
   stopInfo?: StopInfo;
@@ -528,13 +531,15 @@ function StopSection({
   now: Date;
   isFirst?: boolean;
   stopLookup: Map<string, StopInfo>;
+  registerStopRef?: (stopId: string) => (el: HTMLElement | null) => void;
 }) {
   const stopName = stopInfo ? pickStopName(stopInfo, lang) : `Stop ${stopId}`;
   const parsed = parseKmbStopName(stopName);
   const stopCodeBadge = parsed.platform ?? parsed.stopCode ?? null;
+  const stopRef = registerStopRef ? registerStopRef(stopId) : undefined;
 
   return (
-    <div className={cn("space-y-3", !isFirst && "mt-6 border-t pt-6")}>
+    <div ref={stopRef} className={cn("space-y-3", !isFirst && "mt-6 border-t pt-6")}>
       {/* Stop header (sticky within results card) */}
       <div
         className={cn(
@@ -620,6 +625,7 @@ export function KmbResults({
   sentinelRef,
   hasMoreStops,
   precomputedGroups,
+  registerStopRef,
 }: Props) {
   const now = new Date();
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
@@ -866,6 +872,7 @@ export function KmbResults({
                 now={now}
                 isFirst={idx === 0}
                 stopLookup={stopLookup}
+                registerStopRef={registerStopRef}
               />
             ))}
 

--- a/lib/eta/client.ts
+++ b/lib/eta/client.ts
@@ -20,6 +20,37 @@ type DedupeKey = string;
 
 const inFlightJson = new Map<DedupeKey, Promise<unknown>>();
 
+function normalizeRouteFilterKey(routeFilter?: string) {
+  if (!routeFilter) return undefined;
+  const normalized = routeFilter
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => entry.toUpperCase())
+    .sort();
+  return normalized.length ? normalized.join(",") : undefined;
+}
+
+function normalizeStopIdsKey(stopIds: string[]) {
+  return Array.from(
+    new Set(stopIds.map((stopId) => String(stopId ?? "").trim()).filter(Boolean))
+  ).sort();
+}
+
+function normalizeFareVariantKey(variant: KmbFareVariant) {
+  const co = String(variant.co ?? "kmb").toLowerCase();
+  const route = String(variant.route ?? "").toUpperCase();
+  const dir = String(variant.dir ?? "");
+  const serviceType = String(variant.serviceType ?? "");
+  const stopId = String(variant.stopId ?? "").trim();
+  const destCandidates = (variant.destCandidates ?? [])
+    .map((dest) => String(dest ?? "").trim())
+    .filter(Boolean)
+    .sort()
+    .join("~");
+  return `${co}|${route}|${dir}|${serviceType}|${stopId}|${destCandidates}`;
+}
+
 async function fetchJsonDedupe<T>(
   key: DedupeKey,
   fetcher: () => Promise<T>,
@@ -173,13 +204,19 @@ export async function fetchKmbStopEtas(
   stopIds: string[],
   options?: { routeFilter?: string; signal?: AbortSignal; includeFares?: boolean }
 ): Promise<KmbStopEtasResponse> {
+  const keyPayload = {
+    stopIds: normalizeStopIdsKey(stopIds),
+    routeFilter: normalizeRouteFilterKey(options?.routeFilter),
+    includeFares: options?.includeFares ?? false,
+  };
+
   const body = {
     stopIds,
     routeFilter: options?.routeFilter,
     includeFares: options?.includeFares ?? false,
   };
 
-  const key = `kmb:stop-etas:${JSON.stringify(body)}`;
+  const key = `kmb:stop-etas:${JSON.stringify(keyPayload)}`;
 
   return await fetchJsonDedupe(
     key,
@@ -212,8 +249,10 @@ export async function fetchKmbFares(
   variants: KmbFareVariant[],
   options?: { signal?: AbortSignal }
 ): Promise<KmbFaresResponse> {
-  const body = { variants };
-  const key = `kmb:fares:${JSON.stringify(body)}`;
+  const normalizedKeys = Array.from(
+    new Set(variants.map((variant) => normalizeFareVariantKey(variant)))
+  ).sort();
+  const key = `kmb:fares:${JSON.stringify({ variants: normalizedKeys })}`;
 
   return await fetchJsonDedupe(
     key,

--- a/lib/eta/direct/eta-db-list.ts
+++ b/lib/eta/direct/eta-db-list.ts
@@ -12,6 +12,8 @@ export type EtaDbCacheValue = {
   fetchedAt: number;
 };
 
+let inFlightSnapshot: Promise<EtaDbCacheValue> | null = null;
+
 export async function getEtaDbSnapshot(): Promise<EtaDbCacheValue> {
   const cached = await idbGet<EtaDbCacheValue>(ETA_DB_CACHE_KEY);
   const cachedMd5 = await idbGet<string>(ETA_DB_MD5_KEY);
@@ -20,10 +22,22 @@ export async function getEtaDbSnapshot(): Promise<EtaDbCacheValue> {
     return cached.value;
   }
 
-  const [db, md5] = await Promise.all([fetchEtaDb(), fetchEtaDbMd5()]);
-  const payload = { db, md5, fetchedAt: Date.now() };
-  const meta = createMetaForPolicy(CACHE_POLICIES.etaDb);
-  await idbSet(ETA_DB_CACHE_KEY, { value: payload, ...meta });
-  await idbSet(ETA_DB_MD5_KEY, { value: md5, ...meta });
-  return payload;
+  if (inFlightSnapshot) {
+    return await inFlightSnapshot;
+  }
+
+  inFlightSnapshot = (async () => {
+    try {
+      const [db, md5] = await Promise.all([fetchEtaDb(), fetchEtaDbMd5()]);
+      const payload = { db, md5, fetchedAt: Date.now() };
+      const meta = createMetaForPolicy(CACHE_POLICIES.etaDb);
+      await idbSet(ETA_DB_CACHE_KEY, { value: payload, ...meta });
+      await idbSet(ETA_DB_MD5_KEY, { value: md5, ...meta });
+      return payload;
+    } finally {
+      inFlightSnapshot = null;
+    }
+  })();
+
+  return await inFlightSnapshot;
 }

--- a/lib/eta/direct/eta-db.ts
+++ b/lib/eta/direct/eta-db.ts
@@ -6,59 +6,21 @@ import { ETA_DB_CACHE_KEY, ETA_DB_MD5_KEY } from "@/lib/eta/cache/keys";
 import { CACHE_POLICIES, createMetaForPolicy, isFresh } from "@/lib/eta/cache/policy";
 import { MicroCache } from "@/lib/eta/cache/micro-cache";
 import { getEtaDbSnapshot, type EtaDbCacheValue as SnapshotValue } from "@/lib/eta/direct/eta-db-list";
+import {
+  buildEtaDbIndexes,
+  normalizeBound,
+  normalizeStopId,
+  routeStopSeqKey,
+  type EtaDbIndexes,
+  type KmbRouteInfoLite,
+  type KmbRouteStopLite,
+  type KmbStopSearchItem,
+} from "@/lib/eta/eta-db-index";
 import type { UiLanguage } from "@/lib/eta/types";
 
 type EtaDbCacheValue = SnapshotValue;
 
-export type KmbStopSearchItem = {
-  stopId: string;
-  nameEn: string;
-  nameTc: string;
-  nameSc: string;
-  lat: number;
-  lng: number;
-};
-
-export type KmbRouteStopLite = {
-  co: Company;
-  route: string;
-  bound: "I" | "O" | string;
-  serviceType: string;
-  seq: number;
-  stopId: string;
-};
-
-export type KmbRouteInfoLite = {
-  co: Company;
-  route: string;
-  bound: "I" | "O" | string;
-  serviceType: string;
-  origin: {
-    en: string;
-    tc: string;
-    sc: string;
-  };
-  destination: {
-    en: string;
-    tc: string;
-    sc: string;
-  };
-  routeEntry: RouteListEntry;
-};
-
-type BusRouteCandidate = {
-  entry: RouteListEntry;
-  co: Company;
-};
-
-type EtaDbIndexes = {
-  kmbRouteListEntries: RouteListEntry[];
-  kmbStops: KmbStopSearchItem[];
-  kmbRouteStops: KmbRouteStopLite[];
-  mtrRoutes: RouteListEntry[];
-  lrtRoutes: RouteListEntry[];
-  stationToRouteIndex: Map<string, BusRouteCandidate[]>;
-};
+export type { EtaDbIndexes, KmbRouteInfoLite, KmbRouteStopLite, KmbStopSearchItem };
 
 const ETA_DB_POLICY = CACHE_POLICIES.etaDb;
 const etaDbCache = new MicroCache<EtaDbCacheValue>({
@@ -90,15 +52,6 @@ function isBusCompany(company: Company): boolean {
 export function toHkBusEtaLanguage(lang: UiLanguage): "en" | "zh" {
   if (lang === "en") return "en";
   return "zh";
-}
-
-function normalizeBound(bound?: string | null): "I" | "O" | string {
-  if (!bound) return "";
-  return bound === "I" || bound === "O" ? bound : bound;
-}
-
-function normalizeStopId(stopId: string): string {
-  return String(stopId ?? "").trim();
 }
 
 function mapEtaLangToUi(eta: { en: string; zh: string }) {
@@ -162,73 +115,7 @@ export async function getEtaDbIndexes(): Promise<EtaDbIndexes> {
     return cachedIndexes.value;
   }
 
-  const kmbRouteListEntries = Object.values(db.routeList).filter((entry) =>
-    entry.co.some((co) => isBusCompany(co) && entry.stops[co]?.length)
-  );
-
-  const kmbRouteStops: KmbRouteStopLite[] = kmbRouteListEntries.flatMap((entry) =>
-    entry.co
-      .filter((co) => isBusCompany(co))
-      .flatMap((co) => {
-        const stops = entry.stops[co] ?? [];
-        const bound = normalizeBound(entry.bound[co]);
-        return stops.map((stopId, idx) => ({
-          co,
-          route: entry.route,
-          bound,
-          serviceType: entry.serviceType,
-          seq: idx + 1,
-          stopId: normalizeStopId(stopId),
-        }));
-      })
-  );
-
-  const busStopIds = new Set(kmbRouteStops.map((entry) => entry.stopId).filter(Boolean));
-  const kmbStops = Object.entries(db.stopList)
-    .map(([stopId, stop]) => ({
-      stopId: normalizeStopId(stopId),
-      nameEn: (stop.name.en ?? "").trim(),
-      nameTc: (stop.name.zh ?? "").trim(),
-      nameSc: (stop.name.zh ?? "").trim(),
-      lat: stop.location.lat,
-      lng: stop.location.lng,
-    }))
-    .filter((s) => s.stopId && s.nameEn && busStopIds.has(s.stopId));
-
-  const mtrRoutes = Object.values(db.routeList).filter((entry) => entry.co.includes("mtr"));
-  const lrtRoutes = Object.values(db.routeList).filter((entry) => entry.co.includes("lightRail"));
-
-  const stationToRouteIndex = new Map<string, BusRouteCandidate[]>();
-  const stationToRouteDedup = new Map<string, Set<string>>();
-  for (const entry of kmbRouteListEntries) {
-    for (const co of entry.co) {
-      if (!isBusCompany(co)) continue;
-      const stops = entry.stops[co] ?? [];
-      for (const stopId of stops) {
-        const key = normalizeStopId(stopId);
-        if (!key) continue;
-        const candidateKey = `${co}|${entry.route.toUpperCase()}|${normalizeBound(entry.bound[co])}|${
-          entry.serviceType
-        }`;
-        const seen = stationToRouteDedup.get(key) ?? new Set<string>();
-        if (seen.has(candidateKey)) continue;
-        seen.add(candidateKey);
-        stationToRouteDedup.set(key, seen);
-        const list = stationToRouteIndex.get(key) ?? [];
-        list.push({ entry, co });
-        stationToRouteIndex.set(key, list);
-      }
-    }
-  }
-
-  const value = {
-    kmbRouteListEntries,
-    kmbStops,
-    kmbRouteStops,
-    mtrRoutes,
-    lrtRoutes,
-    stationToRouteIndex,
-  };
+  const value = buildEtaDbIndexes(db, { busCompanies: BUS_COMPANIES });
 
   cachedIndexes = { md5, value };
   return value;
@@ -309,7 +196,7 @@ export async function fetchKmbEtasForStop(params: {
   language: UiLanguage;
 }): Promise<KmbEta[]> {
   const db = await getEtaDbCached();
-  const { stationToRouteIndex } = await getEtaDbIndexes();
+  const { stationToRouteIndex, routeStopSeqIndex } = await getEtaDbIndexes();
   const stopId = normalizeStopId(params.stopId);
   const routeFilter = params.route ? params.route.toUpperCase() : null;
   const serviceType = params.serviceType ? String(params.serviceType) : null;
@@ -326,18 +213,28 @@ export async function fetchKmbEtasForStop(params: {
   const candidateMap = new Map<string, { entry: RouteListEntry; co: Company; stopIndex: number }>();
 
   for (const { entry, co } of candidates) {
-    const stops = entry.stops[co] ?? [];
-    let smallestIndex = -1;
-    for (let idx = 0; idx < stops.length; idx += 1) {
-      if (normalizeStopId(stops[idx]) === stopId) {
-        smallestIndex = idx;
-        break;
+    const bound = normalizeBound(entry.bound[co]);
+    const seqKey = routeStopSeqKey({
+      co,
+      route: entry.route,
+      bound,
+      serviceType: entry.serviceType,
+      stopId,
+    });
+    let smallestIndex = routeStopSeqIndex.get(seqKey) ?? -1;
+
+    if (smallestIndex < 0) {
+      const stops = entry.stops[co] ?? [];
+      for (let idx = 0; idx < stops.length; idx += 1) {
+        if (normalizeStopId(stops[idx]) === stopId) {
+          smallestIndex = idx;
+          break;
+        }
       }
     }
+
     if (smallestIndex < 0) continue;
-    const key = `${co}|${entry.route.toUpperCase()}|${normalizeBound(entry.bound[co])}|${
-      entry.serviceType
-    }`;
+    const key = `${co}|${entry.route.toUpperCase()}|${bound}|${entry.serviceType}`;
     const existing = candidateMap.get(key);
     if (!existing || smallestIndex < existing.stopIndex) {
       candidateMap.set(key, { entry, co, stopIndex: smallestIndex });
@@ -391,7 +288,6 @@ export async function fetchMtrEtasForStop(params: {
   serviceType: string;
   language: UiLanguage;
 }): Promise<Eta[]> {
-  const db = await getEtaDbCached();
   const { mtrRoutes } = await getEtaDbIndexes();
   const line = params.line.toUpperCase();
   const sta = params.sta.toUpperCase();
@@ -422,7 +318,6 @@ export async function fetchLrtEtasForStop(params: {
   stationId: string;
   language: UiLanguage;
 }): Promise<Eta[]> {
-  const db = await getEtaDbCached();
   const { lrtRoutes } = await getEtaDbIndexes();
   const route = params.route.toUpperCase();
   const bound = normalizeBound(params.bound);

--- a/lib/eta/eta-db-index.ts
+++ b/lib/eta/eta-db-index.ts
@@ -1,0 +1,167 @@
+import type { Company, EtaDb, RouteListEntry } from "hk-bus-eta";
+
+export type KmbStopSearchItem = {
+  stopId: string;
+  nameEn: string;
+  nameTc: string;
+  nameSc: string;
+  lat: number;
+  lng: number;
+};
+
+export type KmbRouteStopLite = {
+  co: Company;
+  route: string;
+  bound: "I" | "O" | string;
+  serviceType: string;
+  seq: number;
+  stopId: string;
+};
+
+export type KmbRouteInfoLite = {
+  co: Company;
+  route: string;
+  bound: "I" | "O" | string;
+  serviceType: string;
+  origin: {
+    en: string;
+    tc: string;
+    sc: string;
+  };
+  destination: {
+    en: string;
+    tc: string;
+    sc: string;
+  };
+  routeEntry: RouteListEntry;
+};
+
+type BusRouteCandidate = {
+  entry: RouteListEntry;
+  co: Company;
+};
+
+export type EtaDbIndexes = {
+  kmbRouteListEntries: RouteListEntry[];
+  kmbStops: KmbStopSearchItem[];
+  kmbRouteStops: KmbRouteStopLite[];
+  mtrRoutes: RouteListEntry[];
+  lrtRoutes: RouteListEntry[];
+  stationToRouteIndex: Map<string, BusRouteCandidate[]>;
+  /** O(1) lookup for stop sequence (0-indexed) by route variant + stopId. */
+  routeStopSeqIndex: Map<string, number>;
+};
+
+export type BuildEtaDbIndexesOptions = {
+  busCompanies: Company[];
+};
+
+export function normalizeBound(bound?: string | null): "I" | "O" | string {
+  if (!bound) return "";
+  return bound === "I" || bound === "O" ? bound : bound;
+}
+
+export function normalizeStopId(stopId: string): string {
+  return String(stopId ?? "").trim();
+}
+
+export function routeStopSeqKey(params: {
+  co: Company;
+  route: string;
+  bound: string;
+  serviceType: string;
+  stopId: string;
+}): string {
+  return `${params.co}|${params.route.toUpperCase()}|${normalizeBound(params.bound)}|${String(
+    params.serviceType ?? ""
+  )}|${normalizeStopId(params.stopId)}`;
+}
+
+export function buildEtaDbIndexes(
+  db: EtaDb,
+  options: BuildEtaDbIndexesOptions
+): EtaDbIndexes {
+  const { busCompanies } = options;
+
+  const kmbRouteListEntries = Object.values(db.routeList).filter((entry) =>
+    entry.co.some((co) => busCompanies.includes(co) && entry.stops[co]?.length)
+  );
+
+  const routeStopSeqIndex = new Map<string, number>();
+  const kmbRouteStops: KmbRouteStopLite[] = kmbRouteListEntries.flatMap((entry) =>
+    entry.co
+      .filter((co) => busCompanies.includes(co))
+      .flatMap((co) => {
+        const stops = entry.stops[co] ?? [];
+        const bound = normalizeBound(entry.bound[co]);
+        return stops.map((stopId, idx) => {
+          const normalizedStopId = normalizeStopId(stopId);
+          const seqKey = routeStopSeqKey({
+            co,
+            route: entry.route,
+            bound,
+            serviceType: entry.serviceType,
+            stopId: normalizedStopId,
+          });
+          if (normalizedStopId && !routeStopSeqIndex.has(seqKey)) {
+            routeStopSeqIndex.set(seqKey, idx);
+          }
+          return {
+            co,
+            route: entry.route,
+            bound,
+            serviceType: entry.serviceType,
+            seq: idx + 1,
+            stopId: normalizedStopId,
+          };
+        });
+      })
+  );
+
+  const busStopIds = new Set(kmbRouteStops.map((entry) => entry.stopId).filter(Boolean));
+  const kmbStops = Object.entries(db.stopList)
+    .map(([stopId, stop]) => ({
+      stopId: normalizeStopId(stopId),
+      nameEn: (stop.name.en ?? "").trim(),
+      nameTc: (stop.name.zh ?? "").trim(),
+      nameSc: (stop.name.zh ?? "").trim(),
+      lat: stop.location.lat,
+      lng: stop.location.lng,
+    }))
+    .filter((s) => s.stopId && s.nameEn && busStopIds.has(s.stopId));
+
+  const mtrRoutes = Object.values(db.routeList).filter((entry) => entry.co.includes("mtr"));
+  const lrtRoutes = Object.values(db.routeList).filter((entry) => entry.co.includes("lightRail"));
+
+  const stationToRouteIndex = new Map<string, BusRouteCandidate[]>();
+  const stationToRouteDedup = new Map<string, Set<string>>();
+  for (const entry of kmbRouteListEntries) {
+    for (const co of entry.co) {
+      if (!busCompanies.includes(co)) continue;
+      const stops = entry.stops[co] ?? [];
+      const bound = normalizeBound(entry.bound[co]);
+      for (const stopId of stops) {
+        const key = normalizeStopId(stopId);
+        if (!key) continue;
+        const candidateKey = `${co}|${entry.route.toUpperCase()}|${bound}|${entry.serviceType}`;
+        const seen = stationToRouteDedup.get(key) ?? new Set<string>();
+        if (seen.has(candidateKey)) continue;
+        seen.add(candidateKey);
+        stationToRouteDedup.set(key, seen);
+        const list = stationToRouteIndex.get(key) ?? [];
+        list.push({ entry, co });
+        stationToRouteIndex.set(key, list);
+      }
+    }
+  }
+
+  return {
+    kmbRouteListEntries,
+    kmbStops,
+    kmbRouteStops,
+    mtrRoutes,
+    lrtRoutes,
+    stationToRouteIndex,
+    routeStopSeqIndex,
+  };
+}

--- a/lib/eta/hk-bus-eta.ts
+++ b/lib/eta/hk-bus-eta.ts
@@ -2,6 +2,16 @@ import { fetchEtaDb, fetchEtaDbMd5, fetchEtas } from "hk-bus-eta";
 import type { Company, Eta, EtaDb, RouteListEntry, StopList } from "hk-bus-eta";
 
 import { etaDbCache } from "@/lib/eta/cache";
+import {
+  buildEtaDbIndexes,
+  normalizeBound,
+  normalizeStopId,
+  routeStopSeqKey,
+  type EtaDbIndexes,
+  type KmbRouteInfoLite,
+  type KmbRouteStopLite,
+  type KmbStopSearchItem,
+} from "@/lib/eta/eta-db-index";
 import type { UiLanguage } from "@/lib/eta/types";
 
 type EtaDbCacheValue = {
@@ -10,61 +20,14 @@ type EtaDbCacheValue = {
   fetchedAt: number;
 };
 
-type EtaDbIndexes = {
-  kmbRouteListEntries: RouteListEntry[];
-  kmbStops: KmbStopSearchItem[];
-  kmbRouteStops: KmbRouteStopLite[];
-  mtrRoutes: RouteListEntry[];
-  lrtRoutes: RouteListEntry[];
-  stationToRouteIndex: Map<string, BusRouteCandidate[]>;
-};
-
 const ETA_DB_CACHE_KEY = "hk-bus-eta:db";
 const ETA_DB_MD5_KEY = "hk-bus-eta:md5";
 const ETA_DB_TTL_MS = 24 * 60 * 60 * 1000;
 
 let cachedIndexes: { md5: string; value: EtaDbIndexes } | null = null;
+let inFlightEtaDb: Promise<EtaDbCacheValue> | null = null;
 
-export type KmbStopSearchItem = {
-  stopId: string;
-  nameEn: string;
-  nameTc: string;
-  nameSc: string;
-  lat: number;
-  lng: number;
-};
-
-export type KmbRouteStopLite = {
-  co: Company;
-  route: string;
-  bound: "I" | "O" | string;
-  serviceType: string;
-  seq: number;
-  stopId: string;
-};
-
-export type KmbRouteInfoLite = {
-  co: Company;
-  route: string;
-  bound: "I" | "O" | string;
-  serviceType: string;
-  origin: {
-    en: string;
-    tc: string;
-    sc: string;
-  };
-  destination: {
-    en: string;
-    tc: string;
-    sc: string;
-  };
-  routeEntry: RouteListEntry;
-};
-
-type BusRouteCandidate = {
-  entry: RouteListEntry;
-  co: Company;
-};
+export type { EtaDbIndexes, KmbRouteInfoLite, KmbRouteStopLite, KmbStopSearchItem };
 
 const BUS_COMPANIES: Company[] = [
   "kmb",
@@ -86,15 +49,6 @@ export function toHkBusEtaLanguage(lang: UiLanguage): "en" | "zh" {
   return "zh";
 }
 
-function normalizeBound(bound?: string | null): "I" | "O" | string {
-  if (!bound) return "";
-  return bound === "I" || bound === "O" ? bound : bound;
-}
-
-function normalizeStopId(stopId: string): string {
-  return String(stopId ?? "").trim();
-}
-
 function mapEtaLangToUi(eta: { en: string; zh: string }) {
   return {
     en: eta.en ?? "",
@@ -111,71 +65,7 @@ export async function getEtaDbIndexes(): Promise<EtaDbIndexes> {
     return cachedIndexes.value;
   }
 
-  const kmbRouteListEntries = Object.values(db.routeList).filter((entry) =>
-    entry.co.some((co) => isBusCompany(co) && entry.stops[co]?.length)
-  );
-
-  const kmbRouteStops: KmbRouteStopLite[] = kmbRouteListEntries.flatMap((entry) =>
-    entry.co
-      .filter((co) => isBusCompany(co))
-      .flatMap((co) => {
-        const stops = entry.stops[co] ?? [];
-        const bound = normalizeBound(entry.bound[co]);
-        return stops.map((stopId, idx) => ({
-          co,
-          route: entry.route,
-          bound,
-          serviceType: entry.serviceType,
-          seq: idx + 1,
-          stopId: normalizeStopId(stopId),
-        }));
-      })
-  );
-
-  const busStopIds = new Set(kmbRouteStops.map((entry) => entry.stopId).filter(Boolean));
-  const kmbStops = Object.entries(db.stopList)
-    .map(([stopId, stop]) => ({
-      stopId: normalizeStopId(stopId),
-      nameEn: (stop.name.en ?? "").trim(),
-      nameTc: (stop.name.zh ?? "").trim(),
-      nameSc: (stop.name.zh ?? "").trim(),
-      lat: stop.location.lat,
-      lng: stop.location.lng,
-    }))
-    .filter((s) => s.stopId && s.nameEn && busStopIds.has(s.stopId));
-
-  const mtrRoutes = Object.values(db.routeList).filter((entry) => entry.co.includes("mtr"));
-  const lrtRoutes = Object.values(db.routeList).filter((entry) => entry.co.includes("lightRail"));
-
-  const stationToRouteIndex = new Map<string, BusRouteCandidate[]>();
-  const stationToRouteDedup = new Map<string, Set<string>>();
-  for (const entry of kmbRouteListEntries) {
-    for (const co of entry.co) {
-      if (!isBusCompany(co)) continue;
-      const stops = entry.stops[co] ?? [];
-      for (const stopId of stops) {
-        const key = normalizeStopId(stopId);
-        if (!key) continue;
-        const candidateKey = `${co}|${entry.route.toUpperCase()}|${normalizeBound(entry.bound[co])}|${entry.serviceType}`;
-        const seen = stationToRouteDedup.get(key) ?? new Set<string>();
-        if (seen.has(candidateKey)) continue;
-        seen.add(candidateKey);
-        stationToRouteDedup.set(key, seen);
-        const list = stationToRouteIndex.get(key) ?? [];
-        list.push({ entry, co });
-        stationToRouteIndex.set(key, list);
-      }
-    }
-  }
-
-  const value = {
-    kmbRouteListEntries,
-    kmbStops,
-    kmbRouteStops,
-    mtrRoutes,
-    lrtRoutes,
-    stationToRouteIndex,
-  };
+  const value = buildEtaDbIndexes(db, { busCompanies: BUS_COMPANIES });
 
   if (cachedMd5) {
     cachedIndexes = { md5: cachedMd5, value };
@@ -188,15 +78,29 @@ export async function getEtaDbCached(): Promise<EtaDb> {
   const cached = etaDbCache.get(ETA_DB_CACHE_KEY) as EtaDbCacheValue | undefined;
   if (cached) return cached.db;
 
-  const [db, md5] = await Promise.all([fetchEtaDb(), fetchEtaDbMd5()]);
-  const payload: EtaDbCacheValue = {
-    db,
-    md5,
-    fetchedAt: Date.now(),
-  };
-  etaDbCache.set(ETA_DB_CACHE_KEY, payload, ETA_DB_TTL_MS);
-  etaDbCache.set(ETA_DB_MD5_KEY, md5, ETA_DB_TTL_MS);
-  return db;
+  if (inFlightEtaDb) {
+    const payload = await inFlightEtaDb;
+    return payload.db;
+  }
+
+  inFlightEtaDb = (async () => {
+    try {
+      const [db, md5] = await Promise.all([fetchEtaDb(), fetchEtaDbMd5()]);
+      const payload: EtaDbCacheValue = {
+        db,
+        md5,
+        fetchedAt: Date.now(),
+      };
+      etaDbCache.set(ETA_DB_CACHE_KEY, payload, ETA_DB_TTL_MS);
+      etaDbCache.set(ETA_DB_MD5_KEY, md5, ETA_DB_TTL_MS);
+      return payload;
+    } finally {
+      inFlightEtaDb = null;
+    }
+  })();
+
+  const payload = await inFlightEtaDb;
+  return payload.db;
 }
 
 export async function listKmbStops(): Promise<KmbStopSearchItem[]> {
@@ -274,7 +178,7 @@ export async function fetchKmbEtasForStop(params: {
   language: UiLanguage;
 }): Promise<KmbEta[]> {
   const db = await getEtaDbCached();
-  const { stationToRouteIndex } = await getEtaDbIndexes();
+  const { stationToRouteIndex, routeStopSeqIndex } = await getEtaDbIndexes();
   const stopId = normalizeStopId(params.stopId);
   const routeFilter = params.route ? params.route.toUpperCase() : null;
   const serviceType = params.serviceType ? String(params.serviceType) : null;
@@ -294,16 +198,28 @@ export async function fetchKmbEtasForStop(params: {
   >();
 
   for (const { entry, co } of candidates) {
-    const stops = entry.stops[co] ?? [];
-    let smallestIndex = -1;
-    for (let idx = 0; idx < stops.length; idx += 1) {
-      if (normalizeStopId(stops[idx]) === stopId) {
-        smallestIndex = idx;
-        break;
+    const bound = normalizeBound(entry.bound[co]);
+    const seqKey = routeStopSeqKey({
+      co,
+      route: entry.route,
+      bound,
+      serviceType: entry.serviceType,
+      stopId,
+    });
+    let smallestIndex = routeStopSeqIndex.get(seqKey) ?? -1;
+
+    if (smallestIndex < 0) {
+      const stops = entry.stops[co] ?? [];
+      for (let idx = 0; idx < stops.length; idx += 1) {
+        if (normalizeStopId(stops[idx]) === stopId) {
+          smallestIndex = idx;
+          break;
+        }
       }
     }
+
     if (smallestIndex < 0) continue;
-    const key = `${co}|${entry.route.toUpperCase()}|${normalizeBound(entry.bound[co])}|${entry.serviceType}`;
+    const key = `${co}|${entry.route.toUpperCase()}|${bound}|${entry.serviceType}`;
     const existing = candidateMap.get(key);
     if (!existing || smallestIndex < existing.stopIndex) {
       candidateMap.set(key, { entry, co, stopIndex: smallestIndex });


### PR DESCRIPTION
## Summary
- share hk-bus-eta index building and route-stop seq lookups to cut duplicate CPU work
- dedupe ETA DB snapshot fetches and normalize request keys to reduce redundant calls
- limit auto-refresh in KMB view to visible stops while keeping manual refresh behavior

## Testing
- Not run (not requested)