### PR TITLE
Add age-based stale indicators for results

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -335,6 +335,7 @@ export default function Home() {
                   hasQuery={kmbPaneState?.hasQuery ?? false}
                   error={kmbPaneState?.error ?? null}
                   stale={kmbPaneState?.stale ?? false}
+                  staleByStopId={kmbPaneState?.staleByStopId}
                   lastUpdatedAt={kmbPaneState?.lastUpdatedAt}
                   onRefresh={() => void kmbPaneState?.refresh({ toastOnError: true })}
                   loading={kmbPaneState?.loading}

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -23,6 +23,7 @@ import {
   type KmbRouteInfoLite,
   type KmbRouteStopLite,
 } from "@/lib/eta/client";
+import { STALE_THRESHOLDS_MS } from "@/lib/eta/stale";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
 import type { Company } from "hk-bus-eta";
@@ -41,6 +42,7 @@ type EtaState = {
   loading: boolean;
   error: string | null;
   stale: boolean;
+  staleByStopId: Record<string, { stale: boolean; ageMs: number | null }>;
   lastUpdatedAt: number | null;
 };
 
@@ -52,6 +54,7 @@ type EtaAction =
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         loadedStopIds: string[];
         faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
       };
     }
   | { type: "REFRESH_ERROR"; error: string }
@@ -61,6 +64,7 @@ type EtaAction =
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         newStopIds: string[];
         faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
       };
     }
   | {
@@ -78,6 +82,7 @@ const initialEtaState: EtaState = {
   loading: false,
   error: null,
   stale: false,
+  staleByStopId: {},
   lastUpdatedAt: null,
 };
 
@@ -94,11 +99,21 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         faresByVariantKey: action.payload.faresByVariantKey ?? state.faresByVariantKey,
         loading: false,
         error: null,
-        stale: false,
+        stale: Boolean(
+          action.payload.staleByStopId &&
+            Object.values(action.payload.staleByStopId).some((entry) => entry.stale)
+        ),
+        staleByStopId: action.payload.staleByStopId ?? {},
         lastUpdatedAt: Date.now(),
       };
     case "REFRESH_ERROR":
-      return { ...state, loading: false, error: action.error, stale: true };
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+        stale: true,
+        staleByStopId: {},
+      };
     case "APPEND_STOPS":
       return {
         ...state,
@@ -106,6 +121,7 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         loadedStopIds: [...state.loadedStopIds, ...action.payload.newStopIds],
         faresByVariantKey: { ...state.faresByVariantKey, ...(action.payload.faresByVariantKey ?? {}) },
         loading: false,
+        staleByStopId: { ...state.staleByStopId, ...(action.payload.staleByStopId ?? {}) },
       };
     case "FARES_SUCCESS":
       return {
@@ -396,6 +412,7 @@ export type KmbPaneState = {
   loading: boolean;
   error?: string | null;
   stale?: boolean;
+  staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
   lastUpdatedAt?: number;
   hasQuery: boolean;
   multipleStops: boolean;
@@ -455,6 +472,7 @@ export function KmbPane({
   const kmbEtaError = etaState.error;
   const kmbEtaLastUpdatedAt = etaState.lastUpdatedAt;
   const kmbEtaStale = etaState.stale;
+  const kmbEtaStaleByStopId = etaState.staleByStopId;
   const kmbFaresByVariantKey = etaState.faresByVariantKey;
 
   // ========== OPTIMIZATION: Build search index once when stops load ==========
@@ -749,6 +767,21 @@ export function KmbPane({
         filteredByStopId[stopId] = etas;
       }
 
+      const staleByStopId = result.staleByStopId
+        ? Object.fromEntries(
+            Object.entries(result.staleByStopId).map(([stopId, entry]) => [
+              stopId,
+              {
+                ...entry,
+                stale:
+                  entry.stale ||
+                  (typeof entry.ageMs === "number" &&
+                    entry.ageMs > STALE_THRESHOLDS_MS.kmb),
+              },
+            ])
+          )
+        : undefined;
+
       // Dispatch ETAs immediately (without fares)
       if (options.append) {
         // Append mode: merge with existing state
@@ -759,6 +792,7 @@ export function KmbPane({
           payload: {
             byStopId: filteredByStopId,
             newStopIds,
+            staleByStopId,
             // Don't include fares - they'll be fetched in background
           },
         });
@@ -769,6 +803,7 @@ export function KmbPane({
           payload: {
             byStopId: filteredByStopId,
             loadedStopIds: stopIds,
+            staleByStopId,
             // Keep existing fares - they'll be updated in background
           },
         });
@@ -1350,6 +1385,7 @@ export function KmbPane({
       loading: kmbEtaLoading,
       error: kmbEtaError,
       stale: kmbEtaStale,
+      staleByStopId: kmbEtaStaleByStopId,
       lastUpdatedAt: kmbEtaLastUpdatedAt ?? undefined,
       hasQuery: Boolean(kmbQuery),
       multipleStops: kmbQuery?.mode === "stops" || kmbQuery?.mode === "contains",
@@ -1371,6 +1407,7 @@ export function KmbPane({
       kmbEtaError,
       kmbEtaLastUpdatedAt,
       kmbEtaStale,
+      kmbEtaStaleByStopId,
       kmbQuery,
       kmbResultsInfo.code,
       kmbResultsInfo.title,

--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -23,6 +23,7 @@ import { Marquee } from "@/components/ui/marquee";
 import type { KmbEtaEntryWithLeg, KmbRouteInfoLite } from "@/lib/eta/client";
 import { formatRelativeMinutes } from "@/lib/eta/format";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
+import { formatRelativeAgeLabel, isStaleByAge } from "@/lib/eta/stale";
 import type { UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
 
@@ -206,6 +207,7 @@ type Props = {
   hasQuery: boolean;
   lastUpdatedAt?: number;
   stale?: boolean;
+  staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
   error?: string | null;
   onRefresh: () => void;
   loading?: boolean;
@@ -617,6 +619,7 @@ export function KmbResults({
   hasQuery,
   lastUpdatedAt,
   stale,
+  staleByStopId,
   error,
   onRefresh,
   loading,
@@ -631,6 +634,12 @@ export function KmbResults({
 }: Props) {
   const now = new Date();
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+  const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang, now });
+  const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: "kmb", now });
+  const hasStaleStops = Boolean(
+    staleByStopId && Object.values(staleByStopId).some((entry) => entry.stale)
+  );
+  const showStale = Boolean(stale || isAgeStale || hasStaleStops);
 
   // Create a lookup map for stops by ID
   const stopLookup = React.useMemo(() => {
@@ -836,10 +845,16 @@ export function KmbResults({
                       ? `更新 ${updatedAt.toLocaleTimeString()}`
                       : `更新 ${updatedAt.toLocaleTimeString()}`}
                 </span>
+                {relativeAgeLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{relativeAgeLabel}</span>
+                  </>
+                ) : null}
               </>
             ) : null}
 
-            {stale ? (
+            {showStale ? (
               <Badge variant="destructive" className="rounded-lg">
                 {lang === "en" ? "Stale" : lang === "sc" ? "未更新" : "未更新"}
               </Badge>

--- a/components/eta/results-lrt.tsx
+++ b/components/eta/results-lrt.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Marquee } from "@/components/ui/marquee";
 import { getLineColor } from "@/lib/eta/line-colors";
+import { formatRelativeAgeLabel, isStaleByAge } from "@/lib/eta/stale";
 import type { LrtScheduleResponse } from "@/lib/eta/lrt";
 import type { UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
@@ -36,6 +37,9 @@ type Props = {
 
 export function LrtResults({ title, lang, schedule, error, stale, lastUpdatedAt, onRefresh, loading }: Props) {
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+  const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang });
+  const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: "lrt" });
+  const showStale = Boolean(stale || isAgeStale);
 
   const t = {
     systemTime: lang === "en" ? "System time" : lang === "sc" ? "系统时间" : "系統時間",
@@ -64,9 +68,15 @@ export function LrtResults({ title, lang, schedule, error, stale, lastUpdatedAt,
                       ? `更新 ${updatedAt.toLocaleTimeString()}`
                       : `更新 ${updatedAt.toLocaleTimeString()}`}
                 </span>
+                {relativeAgeLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{relativeAgeLabel}</span>
+                  </>
+                ) : null}
               </>
             ) : null}
-            {stale ? (
+            {showStale ? (
               <Badge variant="destructive" className="rounded-lg">
                 {lang === "en" ? "Stale" : lang === "sc" ? "未更新" : "未更新"}
               </Badge>

--- a/components/eta/results-mtr.tsx
+++ b/components/eta/results-mtr.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Marquee } from "@/components/ui/marquee";
 import { findMtrStationBySta } from "@/lib/data/mtr-stations";
 import { getLineColor } from "@/lib/eta/line-colors";
+import { formatRelativeAgeLabel, isStaleByAge } from "@/lib/eta/stale";
 import type { MtrScheduleResponse } from "@/lib/eta/mtr";
 import type { UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
@@ -106,6 +107,9 @@ export function MtrResults({
   loading,
 }: Props) {
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+  const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang });
+  const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: "mtr" });
+  const showStale = Boolean(stale || isAgeStale);
 
   const t = {
     nextTrain:
@@ -149,9 +153,15 @@ export function MtrResults({
                       ? `更新 ${updatedAt.toLocaleTimeString()}`
                       : `更新 ${updatedAt.toLocaleTimeString()}`}
                 </span>
+                {relativeAgeLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{relativeAgeLabel}</span>
+                  </>
+                ) : null}
               </>
             ) : null}
-            {stale ? (
+            {showStale ? (
               <Badge variant="destructive" className="rounded-lg">
                 {lang === "en" ? "Stale" : lang === "sc" ? "未更新" : "未更新"}
               </Badge>

--- a/lib/eta/stale.ts
+++ b/lib/eta/stale.ts
@@ -1,0 +1,56 @@
+import { formatRelativeMinutes } from "@/lib/eta/format";
+import type { UiLanguage } from "@/lib/eta/types";
+
+export type StaleMode = "kmb" | "mtr" | "lrt";
+
+export const STALE_THRESHOLDS_MS: Record<StaleMode, number> = {
+  kmb: 120_000,
+  mtr: 180_000,
+  lrt: 180_000,
+};
+
+export function isStaleByAge(params: {
+  lastUpdatedAt?: number | null;
+  mode: StaleMode;
+  now?: number | Date;
+}) {
+  const lastUpdatedAt = params.lastUpdatedAt;
+  if (!lastUpdatedAt) return false;
+  const nowMs =
+    params.now instanceof Date
+      ? params.now.getTime()
+      : typeof params.now === "number"
+        ? params.now
+        : Date.now();
+  return nowMs - lastUpdatedAt > STALE_THRESHOLDS_MS[params.mode];
+}
+
+export function formatRelativeAgeLabel(params: {
+  lastUpdatedAt?: number | null;
+  lang: UiLanguage;
+  now?: Date;
+}) {
+  const lastUpdatedAt = params.lastUpdatedAt;
+  if (!lastUpdatedAt) return null;
+
+  const now = params.now ?? new Date();
+  const updatedAt = new Date(lastUpdatedAt);
+  const updatedAtTime = updatedAt.getTime();
+  if (Number.isNaN(updatedAtTime)) return null;
+
+  const diffMs = now.getTime() - updatedAtTime;
+  if (diffMs < 0) return null;
+  if (diffMs < 30_000) {
+    return params.lang === "en" ? "just now" : params.lang === "sc" ? "刚刚" : "剛剛";
+  }
+
+  const minutes = Math.abs(formatRelativeMinutes(updatedAt.toISOString(), now));
+  if (minutes < 60) {
+    if (params.lang === "en") return `${minutes} min ago`;
+    return `${minutes} ${params.lang === "sc" ? "分钟前" : "分鐘前"}`;
+  }
+
+  const hours = Math.max(1, Math.round(minutes / 60));
+  if (params.lang === "en") return `${hours} hr${hours === 1 ? "" : "s"} ago`;
+  return `${hours} ${params.lang === "sc" ? "小时前" : "小時前"}`;
+}


### PR DESCRIPTION
## Summary
- add centralized stale thresholds and relative-age formatter
- compute age-based staleness for KMB and merge per-stop stale metadata
- display relative age + stale badge logic in KMB/MTR/LRT result headers