### PR TITLE
feat: favorites pinning, ordering, and groups

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -335,6 +335,7 @@ export default function Home() {
                   hasQuery={kmbPaneState?.hasQuery ?? false}
                   error={kmbPaneState?.error ?? null}
                   stale={kmbPaneState?.stale ?? false}
+                  staleByStopId={kmbPaneState?.staleByStopId}
                   lastUpdatedAt={kmbPaneState?.lastUpdatedAt}
                   onRefresh={() => void kmbPaneState?.refresh({ toastOnError: true })}
                   loading={kmbPaneState?.loading}

--- a/components/eta/favorites.tsx
+++ b/components/eta/favorites.tsx
@@ -1,10 +1,29 @@
 "use client";
 
-import { Heart, History, Trash2 } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  FolderPlus,
+  Heart,
+  History,
+  Pencil,
+  Pin,
+  PinOff,
+  Trash2,
+} from "lucide-react";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { LRT_STATIONS, type LrtStation } from "@/lib/data/lrt-stations";
@@ -12,7 +31,12 @@ import { MTR_STATIONS, type MtrStation } from "@/lib/data/mtr-stations";
 import { getLineColor } from "@/lib/eta/line-colors";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
-import { useAppStore, type FavoritesItem } from "@/lib/store";
+import { cn } from "@/lib/utils";
+import {
+  type FavoritesGroup,
+  type FavoritesItem,
+  useAppStore,
+} from "@/lib/store";
 
 type Props = {
   lang: UiLanguage;
@@ -146,9 +170,19 @@ function FavoriteItemDisplay({
 
 export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
   const favorites = useAppStore((s) => s.favorites);
+  const favoritesGroups = useAppStore((s) => s.favoritesGroups);
   const recents = useAppStore((s) => s.recents);
   const removeFavorite = useAppStore((s) => s.removeFavorite);
+  const toggleFavoritePin = useAppStore((s) => s.toggleFavoritePin);
+  const moveFavorite = useAppStore((s) => s.moveFavorite);
+  const addFavoriteGroup = useAppStore((s) => s.addFavoriteGroup);
+  const renameFavoriteGroup = useAppStore((s) => s.renameFavoriteGroup);
+  const deleteFavoriteGroup = useAppStore((s) => s.deleteFavoriteGroup);
+  const assignFavoriteGroup = useAppStore((s) => s.assignFavoriteGroup);
   const clearRecents = useAppStore((s) => s.clearRecents);
+  const [newGroupName, setNewGroupName] = React.useState("");
+  const [editingGroupId, setEditingGroupId] = React.useState<string | null>(null);
+  const [editingGroupName, setEditingGroupName] = React.useState("");
   const dateFormatter = new Intl.DateTimeFormat(
     lang === "en" ? "en-HK" : lang === "sc" ? "zh-Hans-HK" : "zh-Hant-HK",
     {
@@ -183,6 +217,58 @@ export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
     tip: lang === "en" ? "Tip: results can auto-refresh while you wait." : lang === "sc" ? "提示：結果可在等待時自動刷新。" : "提示：結果可在等待時自動刷新。",
     clear: lang === "en" ? "Clear" : "清除",
     noRecent: lang === "en" ? "No recent searches." : lang === "sc" ? "暫無搜尋記錄。" : "暫無搜尋記錄。",
+    pinned: lang === "en" ? "Pinned" : lang === "sc" ? "已釘選" : "已釘選",
+    unpinned: lang === "en" ? "Unpinned" : lang === "sc" ? "取消釘選" : "取消釘選",
+    moveUp: lang === "en" ? "Move up" : lang === "sc" ? "上移" : "上移",
+    moveDown: lang === "en" ? "Move down" : lang === "sc" ? "下移" : "下移",
+    group: lang === "en" ? "Group" : lang === "sc" ? "分組" : "分組",
+    groups: lang === "en" ? "Groups" : lang === "sc" ? "分組" : "分組",
+    addGroup: lang === "en" ? "Add group" : lang === "sc" ? "新增分組" : "新增分組",
+    rename: lang === "en" ? "Rename" : lang === "sc" ? "重新命名" : "重新命名",
+    delete: lang === "en" ? "Delete" : lang === "sc" ? "刪除" : "刪除",
+    none: lang === "en" ? "None" : lang === "sc" ? "無" : "無",
+  };
+
+  const groupNameById = React.useMemo(() => {
+    return new Map(favoritesGroups.map((group) => [group.id, group.name]));
+  }, [favoritesGroups]);
+
+  const handleAddGroup = () => {
+    if (!newGroupName.trim()) return;
+    addFavoriteGroup(newGroupName);
+    setNewGroupName("");
+  };
+
+  const startEditGroup = (group: FavoritesGroup) => {
+    setEditingGroupId(group.id);
+    setEditingGroupName(group.name);
+  };
+
+  const cancelEditGroup = () => {
+    setEditingGroupId(null);
+    setEditingGroupName("");
+  };
+
+  const saveEditGroup = () => {
+    if (!editingGroupId || !editingGroupName.trim()) return;
+    renameFavoriteGroup(editingGroupId, editingGroupName);
+    cancelEditGroup();
+  };
+
+  const handleGroupInputKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    handleAddGroup();
+  };
+
+  const handleGroupEditKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    saveEditGroup();
   };
 
   return (
@@ -202,11 +288,101 @@ export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
 
         <CardContent className="p-0">
           <TabsContent value="favorites" className="mt-0 p-6 pt-0">
-            <div className="space-y-2">
+            <div className="space-y-4">
+              <div className="space-y-2 rounded-2xl border bg-background/40 p-3">
+                <div className="text-xs font-medium text-muted-foreground">
+                  {t.groups}
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Input
+                    value={newGroupName}
+                    onChange={(event) => setNewGroupName(event.target.value)}
+                    onKeyDown={handleGroupInputKeyDown}
+                    placeholder={t.addGroup}
+                    className="h-8 w-44 rounded-xl text-sm"
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="rounded-xl"
+                    onClick={handleAddGroup}
+                    disabled={!newGroupName.trim()}
+                  >
+                    <FolderPlus className="h-4 w-4" />
+                    <span className="ml-1.5 text-xs">{t.addGroup}</span>
+                  </Button>
+                </div>
+                {favoritesGroups.length > 0 && (
+                  <div className="space-y-1">
+                    {favoritesGroups.map((group) => (
+                      <div
+                        key={group.id}
+                        className="flex items-center justify-between gap-2 text-sm"
+                      >
+                        {editingGroupId === group.id ? (
+                          <div className="flex w-full items-center gap-2">
+                            <Input
+                              value={editingGroupName}
+                              onChange={(event) =>
+                                setEditingGroupName(event.target.value)
+                              }
+                              onKeyDown={handleGroupEditKeyDown}
+                              className="h-8 flex-1 rounded-xl text-sm"
+                            />
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="rounded-xl"
+                              onClick={saveEditGroup}
+                              disabled={!editingGroupName.trim()}
+                            >
+                              {t.rename}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="rounded-xl"
+                              onClick={cancelEditGroup}
+                            >
+                              {t.clear}
+                            </Button>
+                          </div>
+                        ) : (
+                          <>
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">{group.name}</span>
+                            </div>
+                            <div className="flex items-center gap-1">
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8 rounded-xl"
+                                aria-label={t.rename}
+                                onClick={() => startEditGroup(group)}
+                              >
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8 rounded-xl text-destructive"
+                                aria-label={t.delete}
+                                onClick={() => deleteFavoriteGroup(group.id)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
               {favorites.length === 0 ? (
                 <div className="text-sm text-muted-foreground">{t.noFavorites}</div>
               ) : (
-                favorites.map((f) => (
+                favorites.map((f, index) => (
                   <div
                     key={f.id}
                     className="ui-animate-in-fast ui-lift flex items-center justify-between gap-2 rounded-2xl border bg-background/40 px-3 py-2"
@@ -226,24 +402,103 @@ export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
                         />
                       </div>
                       <div className="truncate text-xs text-muted-foreground">
-                        {f.mode.toUpperCase()}
+                        <span>{f.mode.toUpperCase()}</span>
+                        <span className="mx-1">·</span>
+                        <span>{groupNameById.get(f.groupId ?? "") ?? t.none}</span>
                       </div>
                     </button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="rounded-xl"
-                      aria-label={
-                        lang === "en"
-                          ? "Remove favorite"
-                          : lang === "sc"
-                            ? "移除收藏"
-                            : "移除收藏"
-                      }
-                      onClick={() => removeFavorite(f.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 rounded-xl"
+                        aria-label={f.pinned ? t.unpinned : t.pinned}
+                        onClick={() => toggleFavoritePin(f.id)}
+                      >
+                        {f.pinned ? (
+                          <PinOff className="h-4 w-4" />
+                        ) : (
+                          <Pin className="h-4 w-4" />
+                        )}
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 rounded-xl"
+                        aria-label={t.moveUp}
+                        onClick={() => moveFavorite(f.id, "up")}
+                        disabled={
+                          index === 0 ||
+                          Boolean(f.pinned) !== Boolean(favorites[index - 1]?.pinned)
+                        }
+                      >
+                        <ArrowUp className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 rounded-xl"
+                        aria-label={t.moveDown}
+                        onClick={() => moveFavorite(f.id, "down")}
+                        disabled={
+                          index === favorites.length - 1 ||
+                          Boolean(f.pinned) !== Boolean(favorites[index + 1]?.pinned)
+                        }
+                      >
+                        <ArrowDown className="h-4 w-4" />
+                      </Button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-8 w-8 rounded-xl"
+                            aria-label={t.group}
+                          >
+                            <span
+                              className={cn(
+                                "text-xs font-medium",
+                                f.groupId ? "text-foreground" : "text-muted-foreground"
+                              )}
+                            >
+                              {t.group}
+                            </span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="min-w-[10rem]">
+                          <DropdownMenuLabel>{t.group}</DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => assignFavoriteGroup(f.id, null)}
+                          >
+                            {t.none}
+                          </DropdownMenuItem>
+                          {favoritesGroups.map((group) => (
+                            <DropdownMenuItem
+                              key={group.id}
+                              onClick={() => assignFavoriteGroup(f.id, group.id)}
+                            >
+                              {group.name}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 rounded-xl"
+                        aria-label={
+                          lang === "en"
+                            ? "Remove favorite"
+                            : lang === "sc"
+                              ? "移除收藏"
+                              : "移除收藏"
+                        }
+                        onClick={() => removeFavorite(f.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </div>
                 ))
               )}

--- a/components/eta/favorites.tsx
+++ b/components/eta/favorites.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
 } from "lucide-react";
 import * as React from "react";
+import { useShallow } from "zustand/shallow";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -169,9 +170,13 @@ function FavoriteItemDisplay({
 }
 
 export function FavoritesAndRecents({ lang, kmbStops, onSelect }: Props) {
-  const favorites = useAppStore((s) => s.favorites);
-  const favoritesGroups = useAppStore((s) => s.favoritesGroups);
-  const recents = useAppStore((s) => s.recents);
+  const { favorites, favoritesGroups, recents } = useAppStore(
+    useShallow((s) => ({
+      favorites: s.favorites,
+      favoritesGroups: s.favoritesGroups,
+      recents: s.recents,
+    }))
+  );
   const removeFavorite = useAppStore((s) => s.removeFavorite);
   const toggleFavoritePin = useAppStore((s) => s.toggleFavoritePin);
   const moveFavorite = useAppStore((s) => s.moveFavorite);

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -23,6 +23,7 @@ import {
   type KmbRouteInfoLite,
   type KmbRouteStopLite,
 } from "@/lib/eta/client";
+import { STALE_THRESHOLDS_MS } from "@/lib/eta/stale";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
 import type { Company } from "hk-bus-eta";
@@ -41,6 +42,7 @@ type EtaState = {
   loading: boolean;
   error: string | null;
   stale: boolean;
+  staleByStopId: Record<string, { stale: boolean; ageMs: number | null }>;
   lastUpdatedAt: number | null;
 };
 
@@ -52,6 +54,7 @@ type EtaAction =
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         loadedStopIds: string[];
         faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
       };
     }
   | { type: "REFRESH_ERROR"; error: string }
@@ -61,6 +64,7 @@ type EtaAction =
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         newStopIds: string[];
         faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
       };
     }
   | {
@@ -78,6 +82,7 @@ const initialEtaState: EtaState = {
   loading: false,
   error: null,
   stale: false,
+  staleByStopId: {},
   lastUpdatedAt: null,
 };
 
@@ -94,11 +99,21 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         faresByVariantKey: action.payload.faresByVariantKey ?? state.faresByVariantKey,
         loading: false,
         error: null,
-        stale: false,
+        stale: Boolean(
+          action.payload.staleByStopId &&
+            Object.values(action.payload.staleByStopId).some((entry) => entry.stale)
+        ),
+        staleByStopId: action.payload.staleByStopId ?? {},
         lastUpdatedAt: Date.now(),
       };
     case "REFRESH_ERROR":
-      return { ...state, loading: false, error: action.error, stale: true };
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+        stale: true,
+        staleByStopId: {},
+      };
     case "APPEND_STOPS":
       return {
         ...state,
@@ -106,6 +121,7 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         loadedStopIds: [...state.loadedStopIds, ...action.payload.newStopIds],
         faresByVariantKey: { ...state.faresByVariantKey, ...(action.payload.faresByVariantKey ?? {}) },
         loading: false,
+        staleByStopId: { ...state.staleByStopId, ...(action.payload.staleByStopId ?? {}) },
       };
     case "FARES_SUCCESS":
       return {
@@ -396,6 +412,7 @@ export type KmbPaneState = {
   loading: boolean;
   error?: string | null;
   stale?: boolean;
+  staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
   lastUpdatedAt?: number;
   hasQuery: boolean;
   multipleStops: boolean;
@@ -455,6 +472,7 @@ export function KmbPane({
   const kmbEtaError = etaState.error;
   const kmbEtaLastUpdatedAt = etaState.lastUpdatedAt;
   const kmbEtaStale = etaState.stale;
+  const kmbEtaStaleByStopId = etaState.staleByStopId;
   const kmbFaresByVariantKey = etaState.faresByVariantKey;
 
   // ========== OPTIMIZATION: Build search index once when stops load ==========
@@ -749,6 +767,21 @@ export function KmbPane({
         filteredByStopId[stopId] = etas;
       }
 
+      const staleByStopId = result.staleByStopId
+        ? Object.fromEntries(
+            Object.entries(result.staleByStopId).map(([stopId, entry]) => [
+              stopId,
+              {
+                ...entry,
+                stale:
+                  entry.stale ||
+                  (typeof entry.ageMs === "number" &&
+                    entry.ageMs > STALE_THRESHOLDS_MS.kmb),
+              },
+            ])
+          )
+        : undefined;
+
       // Dispatch ETAs immediately (without fares)
       if (options.append) {
         // Append mode: merge with existing state
@@ -759,6 +792,7 @@ export function KmbPane({
           payload: {
             byStopId: filteredByStopId,
             newStopIds,
+            staleByStopId,
             // Don't include fares - they'll be fetched in background
           },
         });
@@ -769,6 +803,7 @@ export function KmbPane({
           payload: {
             byStopId: filteredByStopId,
             loadedStopIds: stopIds,
+            staleByStopId,
             // Keep existing fares - they'll be updated in background
           },
         });
@@ -1350,6 +1385,7 @@ export function KmbPane({
       loading: kmbEtaLoading,
       error: kmbEtaError,
       stale: kmbEtaStale,
+      staleByStopId: kmbEtaStaleByStopId,
       lastUpdatedAt: kmbEtaLastUpdatedAt ?? undefined,
       hasQuery: Boolean(kmbQuery),
       multipleStops: kmbQuery?.mode === "stops" || kmbQuery?.mode === "contains",
@@ -1371,6 +1407,7 @@ export function KmbPane({
       kmbEtaError,
       kmbEtaLastUpdatedAt,
       kmbEtaStale,
+      kmbEtaStaleByStopId,
       kmbQuery,
       kmbResultsInfo.code,
       kmbResultsInfo.title,

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -23,6 +23,7 @@ import {
   type KmbRouteInfoLite,
   type KmbRouteStopLite,
 } from "@/lib/eta/client";
+import { isStaleByFlagOrAge } from "@/lib/eta/stale";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
 import type { Company } from "hk-bus-eta";
@@ -41,6 +42,7 @@ type EtaState = {
   loading: boolean;
   error: string | null;
   stale: boolean;
+  staleByStopId: Record<string, { stale: boolean; ageMs: number | null }>;
   lastUpdatedAt: number | null;
 };
 
@@ -52,6 +54,7 @@ type EtaAction =
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         loadedStopIds: string[];
         faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
       };
     }
   | { type: "REFRESH_ERROR"; error: string }
@@ -61,6 +64,7 @@ type EtaAction =
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         newStopIds: string[];
         faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
       };
     }
   | {
@@ -78,6 +82,7 @@ const initialEtaState: EtaState = {
   loading: false,
   error: null,
   stale: false,
+  staleByStopId: {},
   lastUpdatedAt: null,
 };
 
@@ -94,11 +99,21 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         faresByVariantKey: action.payload.faresByVariantKey ?? state.faresByVariantKey,
         loading: false,
         error: null,
-        stale: false,
+        stale: Boolean(
+          action.payload.staleByStopId &&
+            Object.values(action.payload.staleByStopId).some((entry) => entry.stale)
+        ),
+        staleByStopId: action.payload.staleByStopId ?? {},
         lastUpdatedAt: Date.now(),
       };
     case "REFRESH_ERROR":
-      return { ...state, loading: false, error: action.error, stale: true };
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+        stale: true,
+        staleByStopId: {},
+      };
     case "APPEND_STOPS":
       return {
         ...state,
@@ -106,6 +121,7 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         loadedStopIds: [...state.loadedStopIds, ...action.payload.newStopIds],
         faresByVariantKey: { ...state.faresByVariantKey, ...(action.payload.faresByVariantKey ?? {}) },
         loading: false,
+        staleByStopId: { ...state.staleByStopId, ...(action.payload.staleByStopId ?? {}) },
       };
     case "FARES_SUCCESS":
       return {
@@ -396,6 +412,7 @@ export type KmbPaneState = {
   loading: boolean;
   error?: string | null;
   stale?: boolean;
+  staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
   lastUpdatedAt?: number;
   hasQuery: boolean;
   multipleStops: boolean;
@@ -459,6 +476,7 @@ export function KmbPane({
   const kmbEtaError = etaState.error;
   const kmbEtaLastUpdatedAt = etaState.lastUpdatedAt;
   const kmbEtaStale = etaState.stale;
+  const kmbEtaStaleByStopId = etaState.staleByStopId;
   const kmbFaresByVariantKey = etaState.faresByVariantKey;
 
   // ========== OPTIMIZATION: Build search index once when stops load ==========
@@ -760,6 +778,22 @@ export function KmbPane({
         filteredByStopId[stopId] = etas;
       }
 
+      const staleByStopId = result.staleByStopId
+        ? Object.fromEntries(
+            Object.entries(result.staleByStopId).map(([stopId, entry]) => [
+              stopId,
+              {
+                ...entry,
+                stale: isStaleByFlagOrAge({
+                  upstreamStale: entry.stale,
+                  ageMs: entry.ageMs,
+                  mode: "kmb",
+                }),
+              },
+            ])
+          )
+        : undefined;
+
       // Dispatch ETAs immediately (without fares)
       if (options.append) {
         // Append mode: merge with existing state
@@ -770,6 +804,7 @@ export function KmbPane({
           payload: {
             byStopId: filteredByStopId,
             newStopIds,
+            staleByStopId,
             // Don't include fares - they'll be fetched in background
           },
         });
@@ -784,6 +819,7 @@ export function KmbPane({
           payload: {
             byStopId: mergedByStopId,
             loadedStopIds: nextLoadedStopIds,
+            staleByStopId,
             // Keep existing fares - they'll be updated in background
           },
         });
@@ -1395,6 +1431,7 @@ export function KmbPane({
       loading: kmbEtaLoading,
       error: kmbEtaError,
       stale: kmbEtaStale,
+      staleByStopId: kmbEtaStaleByStopId,
       lastUpdatedAt: kmbEtaLastUpdatedAt ?? undefined,
       hasQuery: Boolean(kmbQuery),
       multipleStops: kmbQuery?.mode === "stops" || kmbQuery?.mode === "contains",
@@ -1418,6 +1455,7 @@ export function KmbPane({
       kmbEtaError,
       kmbEtaLastUpdatedAt,
       kmbEtaStale,
+      kmbEtaStaleByStopId,
       kmbQuery,
       kmbResultsInfo.code,
       kmbResultsInfo.title,

--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -23,6 +23,7 @@ import { Marquee } from "@/components/ui/marquee";
 import type { KmbEtaEntryWithLeg, KmbRouteInfoLite } from "@/lib/eta/client";
 import { formatRelativeMinutes } from "@/lib/eta/format";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
+import { formatRelativeAgeLabel, isStaleByAge } from "@/lib/eta/stale";
 import type { UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
 
@@ -206,6 +207,7 @@ type Props = {
   hasQuery: boolean;
   lastUpdatedAt?: number;
   stale?: boolean;
+  staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
   error?: string | null;
   onRefresh: () => void;
   loading?: boolean;
@@ -622,6 +624,7 @@ export function KmbResults({
   hasQuery,
   lastUpdatedAt,
   stale,
+  staleByStopId,
   error,
   onRefresh,
   loading,
@@ -637,6 +640,12 @@ export function KmbResults({
 }: Props) {
   const now = new Date();
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+  const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang, now });
+  const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: "kmb", now });
+  const hasStaleStops = Boolean(
+    staleByStopId && Object.values(staleByStopId).some((entry) => entry.stale)
+  );
+  const showStale = Boolean(stale || isAgeStale || hasStaleStops);
 
   // Create a lookup map for stops by ID
   const stopLookup = React.useMemo(() => {
@@ -842,10 +851,16 @@ export function KmbResults({
                       ? `更新 ${updatedAt.toLocaleTimeString()}`
                       : `更新 ${updatedAt.toLocaleTimeString()}`}
                 </span>
+                {relativeAgeLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{relativeAgeLabel}</span>
+                  </>
+                ) : null}
               </>
             ) : null}
 
-            {stale ? (
+            {showStale ? (
               <Badge variant="destructive" className="rounded-lg">
                 {lang === "en" ? "Stale" : lang === "sc" ? "未更新" : "未更新"}
               </Badge>

--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -23,6 +23,7 @@ import { Marquee } from "@/components/ui/marquee";
 import type { KmbEtaEntryWithLeg, KmbRouteInfoLite } from "@/lib/eta/client";
 import { formatRelativeMinutes } from "@/lib/eta/format";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
+import { formatRelativeAgeLabel, isStaleByAge } from "@/lib/eta/stale";
 import type { UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
 
@@ -206,6 +207,7 @@ type Props = {
   hasQuery: boolean;
   lastUpdatedAt?: number;
   stale?: boolean;
+  staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
   error?: string | null;
   onRefresh: () => void;
   loading?: boolean;
@@ -617,6 +619,7 @@ export function KmbResults({
   hasQuery,
   lastUpdatedAt,
   stale,
+  staleByStopId,
   error,
   onRefresh,
   loading,
@@ -631,6 +634,12 @@ export function KmbResults({
 }: Props) {
   const now = new Date();
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+  const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang, now });
+  const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: "kmb", now });
+  const hasStaleStops = Boolean(
+    staleByStopId && Object.values(staleByStopId).some((entry) => entry.stale)
+  );
+  const showStale = Boolean(stale || isAgeStale || hasStaleStops);
 
   // Create a lookup map for stops by ID
   const stopLookup = React.useMemo(() => {
@@ -836,10 +845,16 @@ export function KmbResults({
                       ? `更新 ${updatedAt.toLocaleTimeString()}`
                       : `更新 ${updatedAt.toLocaleTimeString()}`}
                 </span>
+                {relativeAgeLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{relativeAgeLabel}</span>
+                  </>
+                ) : null}
               </>
             ) : null}
 
-            {stale ? (
+            {showStale ? (
               <Badge variant="destructive" className="rounded-lg">
                 {lang === "en" ? "Stale" : lang === "sc" ? "未更新" : "未更新"}
               </Badge>

--- a/components/eta/results-lrt.tsx
+++ b/components/eta/results-lrt.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Marquee } from "@/components/ui/marquee";
 import { getLineColor } from "@/lib/eta/line-colors";
+import { formatRelativeAgeLabel, isStaleByAge } from "@/lib/eta/stale";
 import type { LrtScheduleResponse } from "@/lib/eta/lrt";
 import type { UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
@@ -36,6 +37,9 @@ type Props = {
 
 export function LrtResults({ title, lang, schedule, error, stale, lastUpdatedAt, onRefresh, loading }: Props) {
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+  const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang });
+  const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: "lrt" });
+  const showStale = Boolean(stale || isAgeStale);
 
   const t = {
     systemTime: lang === "en" ? "System time" : lang === "sc" ? "系统时间" : "系統時間",
@@ -64,9 +68,15 @@ export function LrtResults({ title, lang, schedule, error, stale, lastUpdatedAt,
                       ? `更新 ${updatedAt.toLocaleTimeString()}`
                       : `更新 ${updatedAt.toLocaleTimeString()}`}
                 </span>
+                {relativeAgeLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{relativeAgeLabel}</span>
+                  </>
+                ) : null}
               </>
             ) : null}
-            {stale ? (
+            {showStale ? (
               <Badge variant="destructive" className="rounded-lg">
                 {lang === "en" ? "Stale" : lang === "sc" ? "未更新" : "未更新"}
               </Badge>

--- a/components/eta/results-mtr.tsx
+++ b/components/eta/results-mtr.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Marquee } from "@/components/ui/marquee";
 import { findMtrStationBySta } from "@/lib/data/mtr-stations";
 import { getLineColor } from "@/lib/eta/line-colors";
+import { formatRelativeAgeLabel, isStaleByAge } from "@/lib/eta/stale";
 import type { MtrScheduleResponse } from "@/lib/eta/mtr";
 import type { UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
@@ -106,6 +107,9 @@ export function MtrResults({
   loading,
 }: Props) {
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+  const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang });
+  const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: "mtr" });
+  const showStale = Boolean(stale || isAgeStale);
 
   const t = {
     nextTrain:
@@ -149,9 +153,15 @@ export function MtrResults({
                       ? `更新 ${updatedAt.toLocaleTimeString()}`
                       : `更新 ${updatedAt.toLocaleTimeString()}`}
                 </span>
+                {relativeAgeLabel ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{relativeAgeLabel}</span>
+                  </>
+                ) : null}
               </>
             ) : null}
-            {stale ? (
+            {showStale ? (
               <Badge variant="destructive" className="rounded-lg">
                 {lang === "en" ? "Stale" : lang === "sc" ? "未更新" : "未更新"}
               </Badge>

--- a/hk-bus-eta-readme.md
+++ b/hk-bus-eta-readme.md
@@ -1,0 +1,121 @@
+# HK Bus ETA
+
+Bus ETAs in Hong Kong is now available as open data in Hong Kong, while there is no format normalization across different transport provider.  This package is a js package (typescript supported) for querying normalized public traffic ETA (Estimated Time of Arrival) in Hong Kong. The ETA data structure is based on [hkbus/hk-bus-crawling](https://github.com/hkbus/hk-bus-crawling) and a well-established open-source project is known as [hkbus.app](https://hkbus.app/).
+
+A Python version package is available [here](https://pypi.org/project/hk-bus-eta/) and the source code is available [here](https://github.com/hkbus/hk-bus-crawling).
+
+## Demo
+
+Live demo is available [here](https://hk-bus-eta.chunlaw.io/).
+
+## Install
+
+`npm install hk-bus-eta`
+or 
+`yarn add hk-bus-eta`
+
+
+## Usage
+
+__Crawling traffic database:__
+```ts
+import { fetchEtaDb } from "hk-bus-eta";
+import type { EtaDb } from "hk-bus-eta";
+
+(async function () {
+  const etaDb: EtaDb = await fetchEtaDb();
+  console.log(db)
+})();
+```
+
+__Crawling ETA__
+```ts
+import { fetchEtas } from "hk-bus-eta";
+import type { Eta } from "hk-bus-eta";
+
+(async function () {
+  // etaDb is the EtaDb object fetched by fetchEtaObj
+  const etas: Eta[] = await fetchEtas({
+    ...etaDb.routeList["1+1+CHUK YUEN ESTATE+STAR FERRY"],
+    seq: 0,
+    language: "en",
+  });
+  console.log(etas);
+})();
+```
+
+## Data Structure
+The data structure of _EtaDb_ is as follows:
+```ts
+{
+    holidays: string[];
+    routeList: {
+        [routeId: string]: {
+            route: string,
+            co: Company[],
+            orig: {
+                en: string,
+                zh: string
+            },
+            dest: {
+                en: string,
+                zh: string
+            },
+            fares: string[] | null,
+            faresHoliday: string[] | null,
+            freq: {
+                [type: string]: {
+                    [startTime: string]: [string, string] | null
+                }
+            } | null,
+            jt: string | null,
+            seq: number,
+            serviceType: string,
+            stops: {
+                [company: string]: string[]
+            },
+            bound: {
+                [company: string]: "O" | "I" | "OI" | "IO"
+            },
+            gtfsId: string,
+            nlbId: string
+        }
+    }
+    stopList: {
+        [stopId: string]: {
+            location: {
+                lat: number,
+                lng: number,
+            },
+            name: {
+                en: string,
+                zh: string
+            }
+        }
+    }
+    stopMap: {
+        [stopId: string]: Array<{
+          [company: string]: string  
+        }>
+    }
+}
+```
+
+The data structure of _Eta_ is as follows:
+```ts
+{
+  eta: string,
+  remark: {
+    zh: string,
+    en: string
+  },
+  co: string
+}
+```
+
+## Contribute
+Project owner [chunlaw](https://github.com/chunlaw) is the initiator of the whole project. Everyone is welcome to contribute. 
+
+## License
+
+GPL-3.0 license

--- a/lib/eta/stale.test.ts
+++ b/lib/eta/stale.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatRelativeAgeLabel,
+  isStaleByAge,
+  STALE_THRESHOLDS_MS,
+} from "./stale";
+
+describe("isStaleByAge", () => {
+  it("returns false when lastUpdatedAt is undefined", () => {
+    expect(isStaleByAge({ lastUpdatedAt: undefined, mode: "kmb" })).toBe(false);
+  });
+
+  it("returns false when lastUpdatedAt is null", () => {
+    expect(isStaleByAge({ lastUpdatedAt: null, mode: "kmb" })).toBe(false);
+  });
+
+  it("returns false for fresh data (below threshold)", () => {
+    const now = 1000000;
+    const lastUpdatedAt = now - 60000; // 1 minute ago
+    expect(isStaleByAge({ lastUpdatedAt, mode: "kmb", now })).toBe(false);
+  });
+
+  it("returns true for stale data (above threshold)", () => {
+    const now = 1000000;
+    const threshold = STALE_THRESHOLDS_MS.kmb;
+    const lastUpdatedAt = now - threshold - 1000; // Just past threshold
+    expect(isStaleByAge({ lastUpdatedAt, mode: "kmb", now })).toBe(true);
+  });
+
+  it("returns true for kmb mode when age exceeds 120 seconds", () => {
+    const now = 1000000;
+    const lastUpdatedAt = now - 130000; // 130 seconds ago
+    expect(isStaleByAge({ lastUpdatedAt, mode: "kmb", now })).toBe(true);
+  });
+
+  it("returns true for mtr mode when age exceeds 180 seconds", () => {
+    const now = 1000000;
+    const lastUpdatedAt = now - 190000; // 190 seconds ago
+    expect(isStaleByAge({ lastUpdatedAt, mode: "mtr", now })).toBe(true);
+  });
+
+  it("returns true for lrt mode when age exceeds 180 seconds", () => {
+    const now = 1000000;
+    const lastUpdatedAt = now - 190000; // 190 seconds ago
+    expect(isStaleByAge({ lastUpdatedAt, mode: "lrt", now })).toBe(true);
+  });
+
+  it("returns false for mtr mode at 120 seconds (below 180s threshold)", () => {
+    const now = 1000000;
+    const lastUpdatedAt = now - 120000; // 120 seconds ago
+    expect(isStaleByAge({ lastUpdatedAt, mode: "mtr", now })).toBe(false);
+  });
+
+  it("accepts Date object for now parameter", () => {
+    const lastUpdatedAt = 1000000;
+    const now = new Date(lastUpdatedAt + 200000);
+    expect(isStaleByAge({ lastUpdatedAt, mode: "kmb", now })).toBe(true);
+  });
+});
+
+describe("formatRelativeAgeLabel", () => {
+  it("returns null when lastUpdatedAt is undefined", () => {
+    expect(formatRelativeAgeLabel({ lastUpdatedAt: undefined, lang: "en" })).toBe(null);
+  });
+
+  it("returns null when lastUpdatedAt is null", () => {
+    expect(formatRelativeAgeLabel({ lastUpdatedAt: null, lang: "en" })).toBe(null);
+  });
+
+  it("returns null for NaN date", () => {
+    expect(formatRelativeAgeLabel({ lastUpdatedAt: Number.NaN, lang: "en" })).toBe(null);
+  });
+
+  it("returns null for future dates (negative diff)", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() + 60000; // 1 minute in future
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "en", now })).toBe(null);
+  });
+
+  it("returns 'just now' for very recent updates (< 30s)", () => {
+    const now = new Date("2024-01-01T00:00:15.000Z");
+    const lastUpdatedAt = now.getTime() - 10000; // 10 seconds ago
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "en", now })).toBe("just now");
+  });
+
+  it("returns '刚刚' for very recent updates in sc", () => {
+    const now = new Date("2024-01-01T00:00:15.000Z");
+    const lastUpdatedAt = now.getTime() - 10000;
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "sc", now })).toBe("刚刚");
+  });
+
+  it("returns '剛剛' for very recent updates in tc", () => {
+    const now = new Date("2024-01-01T00:00:15.000Z");
+    const lastUpdatedAt = now.getTime() - 10000;
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "tc", now })).toBe("剛剛");
+  });
+
+  it("returns minutes ago for updates within an hour", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() - 5 * 60000; // 5 minutes ago
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "en", now })).toBe("5 min ago");
+  });
+
+  it("returns '分钟前' for updates within an hour in sc", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() - 10 * 60000;
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "sc", now })).toBe("10 分钟前");
+  });
+
+  it("returns '分鐘前' for updates within an hour in tc", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() - 15 * 60000;
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "tc", now })).toBe("15 分鐘前");
+  });
+
+  it("returns hours ago for updates over an hour", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() - 90 * 60000; // 90 minutes ago
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "en", now })).toBe("2 hrs ago");
+  });
+
+  it("returns '1 hr ago' for singular hour", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() - 60 * 60000; // 60 minutes ago
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "en", now })).toBe("1 hr ago");
+  });
+
+  it("returns '小时前' for hours in sc", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() - 120 * 60000;
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "sc", now })).toBe("2 小时前");
+  });
+
+  it("returns '小時前' for hours in tc", () => {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const lastUpdatedAt = now.getTime() - 180 * 60000;
+    expect(formatRelativeAgeLabel({ lastUpdatedAt, lang: "tc", now })).toBe("3 小時前");
+  });
+});

--- a/lib/eta/stale.ts
+++ b/lib/eta/stale.ts
@@ -1,0 +1,56 @@
+import { formatRelativeMinutes } from "@/lib/eta/format";
+import type { UiLanguage } from "@/lib/eta/types";
+
+export type StaleMode = "kmb" | "mtr" | "lrt";
+
+export const STALE_THRESHOLDS_MS: Record<StaleMode, number> = {
+  kmb: 120_000,
+  mtr: 180_000,
+  lrt: 180_000,
+};
+
+export function isStaleByAge(params: {
+  lastUpdatedAt?: number | null;
+  mode: StaleMode;
+  now?: number | Date;
+}) {
+  const lastUpdatedAt = params.lastUpdatedAt;
+  if (!lastUpdatedAt) return false;
+  const nowMs =
+    params.now instanceof Date
+      ? params.now.getTime()
+      : typeof params.now === "number"
+        ? params.now
+        : Date.now();
+  return nowMs - lastUpdatedAt > STALE_THRESHOLDS_MS[params.mode];
+}
+
+export function formatRelativeAgeLabel(params: {
+  lastUpdatedAt?: number | null;
+  lang: UiLanguage;
+  now?: Date;
+}) {
+  const lastUpdatedAt = params.lastUpdatedAt;
+  if (!lastUpdatedAt) return null;
+
+  const now = params.now ?? new Date();
+  const updatedAt = new Date(lastUpdatedAt);
+  const updatedAtTime = updatedAt.getTime();
+  if (Number.isNaN(updatedAtTime)) return null;
+
+  const diffMs = now.getTime() - updatedAtTime;
+  if (diffMs < 0) return null;
+  if (diffMs < 30_000) {
+    return params.lang === "en" ? "just now" : params.lang === "sc" ? "刚刚" : "剛剛";
+  }
+
+  const minutes = Math.abs(formatRelativeMinutes(updatedAt.toISOString(), now));
+  if (minutes < 60) {
+    if (params.lang === "en") return `${minutes} min ago`;
+    return `${minutes} ${params.lang === "sc" ? "分钟前" : "分鐘前"}`;
+  }
+
+  const hours = Math.max(1, Math.round(minutes / 60));
+  if (params.lang === "en") return `${hours} hr${hours === 1 ? "" : "s"} ago`;
+  return `${hours} ${params.lang === "sc" ? "小时前" : "小時前"}`;
+}

--- a/lib/eta/stale.ts
+++ b/lib/eta/stale.ts
@@ -1,0 +1,72 @@
+import { formatRelativeMinutes } from "./format";
+import type { UiLanguage } from "./types";
+
+export type StaleMode = "kmb" | "mtr" | "lrt";
+
+export const STALE_THRESHOLDS_MS: Record<StaleMode, number> = {
+  kmb: 120_000,
+  mtr: 180_000,
+  lrt: 180_000,
+};
+
+export function isStaleByAge(params: {
+  lastUpdatedAt?: number | null;
+  mode: StaleMode;
+  now?: number | Date;
+}) {
+  const lastUpdatedAt = params.lastUpdatedAt;
+  if (!lastUpdatedAt) return false;
+  const nowMs =
+    params.now instanceof Date
+      ? params.now.getTime()
+      : typeof params.now === "number"
+        ? params.now
+        : Date.now();
+  return nowMs - lastUpdatedAt > STALE_THRESHOLDS_MS[params.mode];
+}
+
+/**
+ * Check if data is stale based on both upstream flag and age threshold.
+ * Combines upstream stale status with local age-based staleness check.
+ */
+export function isStaleByFlagOrAge(params: {
+  upstreamStale?: boolean;
+  ageMs?: number | null;
+  mode: StaleMode;
+}): boolean {
+  // If upstream says it's stale, trust that
+  if (params.upstreamStale) return true;
+  // Otherwise check age against threshold
+  if (typeof params.ageMs !== "number") return false;
+  return params.ageMs > STALE_THRESHOLDS_MS[params.mode];
+}
+
+export function formatRelativeAgeLabel(params: {
+  lastUpdatedAt?: number | null;
+  lang: UiLanguage;
+  now?: Date;
+}) {
+  const lastUpdatedAt = params.lastUpdatedAt;
+  if (!lastUpdatedAt) return null;
+
+  const now = params.now ?? new Date();
+  const updatedAt = new Date(lastUpdatedAt);
+  const updatedAtTime = updatedAt.getTime();
+  if (Number.isNaN(updatedAtTime)) return null;
+
+  const diffMs = now.getTime() - updatedAtTime;
+  if (diffMs < 0) return null;
+  if (diffMs < 30_000) {
+    return params.lang === "en" ? "just now" : params.lang === "sc" ? "刚刚" : "剛剛";
+  }
+
+  const minutes = Math.abs(formatRelativeMinutes(updatedAt.toISOString(), now));
+  if (minutes < 60) {
+    if (params.lang === "en") return `${minutes} min ago`;
+    return `${minutes} ${params.lang === "sc" ? "分钟前" : "分鐘前"}`;
+  }
+
+  const hours = Math.max(1, Math.round(minutes / 60));
+  if (params.lang === "en") return `${hours} hr${hours === 1 ? "" : "s"} ago`;
+  return `${hours} ${params.lang === "sc" ? "小时前" : "小時前"}`;
+}

--- a/lib/eta/types.ts
+++ b/lib/eta/types.ts
@@ -40,3 +40,30 @@ export type MtrStationSearchItem = {
   nameEn: string;
   nameTc: string;
 };
+
+// MTR System Map types for schematic map component
+export type MapBranch = {
+  id?: string;
+  from?: string;
+  sequence?: string[];
+  branches?: MapBranch[];
+  notes?: string;
+};
+
+export type MapLine = {
+  id: string;
+  name: string;
+  color: string;
+  loop?: boolean;
+  stations?: string[];
+  trunk?: string[];
+  branches?: MapBranch[];
+};
+
+export type LineSequence = {
+  key: string;
+  id: string;
+  name: string;
+  color: string;
+  stations: string[];
+};

--- a/lib/store.test.ts
+++ b/lib/store.test.ts
@@ -1,0 +1,596 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { create } from "zustand";
+import type { FavoritesItem, FavoritesGroup } from "./store";
+
+// Create a test store without persist middleware
+type AppState = {
+  mode: "kmb" | "mtr" | "lrt";
+  lang: "en" | "tc" | "sc";
+  favorites: FavoritesItem[];
+  favoritesGroups: FavoritesGroup[];
+  recents: Array<FavoritesItem & { at: number }>;
+  addFavorite: (item: FavoritesItem) => void;
+  removeFavorite: (id: string) => void;
+  toggleFavoritePin: (id: string) => void;
+  moveFavorite: (id: string, direction: "up" | "down") => void;
+  addFavoriteGroup: (name: string) => void;
+  renameFavoriteGroup: (id: string, name: string) => void;
+  deleteFavoriteGroup: (id: string) => void;
+  assignFavoriteGroup: (favoriteId: string, groupId: string | null) => void;
+  clearRecents: () => void;
+};
+
+const createId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 10);
+};
+
+const withFavoriteMeta = (item: FavoritesItem): FavoritesItem => ({
+  ...item,
+  pinned: item.pinned ?? false,
+  groupId: item.groupId ?? null,
+});
+
+const createTestStore = () =>
+  create<AppState>((set) => ({
+    mode: "kmb",
+    lang: "tc",
+    favorites: [],
+    favoritesGroups: [],
+    recents: [],
+
+    addFavorite: (item) =>
+      set((state) => {
+        if (state.favorites.some((f) => f.id === item.id)) return state;
+        return { favorites: [withFavoriteMeta(item), ...state.favorites] };
+      }),
+
+    removeFavorite: (id) =>
+      set((state) => ({
+        favorites: state.favorites.filter((f) => f.id !== id),
+      })),
+
+    toggleFavoritePin: (id) =>
+      set((state) => {
+        const favorites = [...state.favorites];
+        const index = favorites.findIndex((f) => f.id === id);
+        if (index === -1) return state;
+
+        const current = favorites[index];
+        const nextPinned = !current.pinned;
+        const updated = { ...current, pinned: nextPinned };
+        favorites.splice(index, 1);
+
+        if (nextPinned) {
+          favorites.unshift(updated);
+        } else {
+          let insertIndex = 0;
+          while (insertIndex < favorites.length && favorites[insertIndex].pinned) {
+            insertIndex += 1;
+          }
+          favorites.splice(insertIndex, 0, updated);
+        }
+
+        return { favorites };
+      }),
+
+    moveFavorite: (id, direction) =>
+      set((state) => {
+        const favorites = [...state.favorites];
+        const index = favorites.findIndex((f) => f.id === id);
+        if (index === -1) return state;
+
+        const targetIndex = direction === "up" ? index - 1 : index + 1;
+        if (targetIndex < 0 || targetIndex >= favorites.length) return state;
+        if (Boolean(favorites[index].pinned) !== Boolean(favorites[targetIndex].pinned)) {
+          return state;
+        }
+
+        const [moved] = favorites.splice(index, 1);
+        favorites.splice(targetIndex, 0, moved);
+        return { favorites };
+      }),
+
+    addFavoriteGroup: (name) =>
+      set((state) => {
+        const trimmed = name.trim();
+        if (!trimmed) return state;
+        const group: FavoritesGroup = { id: createId(), name: trimmed };
+        return { favoritesGroups: [...state.favoritesGroups, group] };
+      }),
+
+    renameFavoriteGroup: (id, name) =>
+      set((state) => {
+        const trimmed = name.trim();
+        if (!trimmed) return state;
+        return {
+          favoritesGroups: state.favoritesGroups.map((group) =>
+            group.id === id ? { ...group, name: trimmed } : group
+          ),
+        };
+      }),
+
+    deleteFavoriteGroup: (id) =>
+      set((state) => ({
+        favorites: state.favorites.map((favorite) =>
+          favorite.groupId === id ? { ...favorite, groupId: null } : favorite
+        ),
+        favoritesGroups: state.favoritesGroups.filter((group) => group.id !== id),
+      })),
+
+    assignFavoriteGroup: (favoriteId, groupId) =>
+      set((state) => ({
+        favorites: state.favorites.map((favorite) =>
+          favorite.id === favoriteId
+            ? { ...favorite, groupId: groupId ?? null }
+            : favorite
+        ),
+      })),
+
+    clearRecents: () => set({ recents: [] }),
+  }));
+
+describe("store favorites", () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  beforeEach(() => {
+    store = createTestStore();
+  });
+
+  describe("toggleFavoritePin", () => {
+    it("pins an unpinned favorite and moves it to the top", () => {
+      // Add two unpinned favorites
+      const item1: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+        pinned: false,
+      };
+      const item2: FavoritesItem = {
+        id: "fav-2",
+        mode: "mtr",
+        title: "Admiralty",
+        line: "TWL",
+        sta: "ADM",
+        pinned: false,
+      };
+
+      store.getState().addFavorite(item1);
+      store.getState().addFavorite(item2);
+
+      // addFavorite prepends items, so order is [item2, item1]
+      expect(store.getState().favorites[0].id).toBe("fav-2");
+      expect(store.getState().favorites[1].id).toBe("fav-1");
+
+      // Pin fav-1 (which is at index 1)
+      store.getState().toggleFavoritePin("fav-1");
+
+      const favorites = store.getState().favorites;
+      // After pinning fav-1, it should move to front
+      expect(favorites[0].id).toBe("fav-1");
+      expect(favorites[0].pinned).toBe(true);
+      expect(favorites[1].id).toBe("fav-2");
+      expect(favorites[1].pinned).toBe(false);
+    });
+
+    it("unpins a pinned favorite and moves it after pinned items", () => {
+      // Create one pinned item
+      const pinnedItem: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+        pinned: true,
+      };
+      store.getState().addFavorite(pinnedItem);
+      expect(store.getState().favorites[0].pinned).toBe(true);
+
+      // Unpin it
+      store.getState().toggleFavoritePin("fav-1");
+
+      // Should now be unpinned
+      expect(store.getState().favorites[0].pinned).toBe(false);
+    });
+
+    it("does nothing for non-existent favorite id", () => {
+      const item: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+      };
+
+      store.getState().addFavorite(item);
+      store.getState().toggleFavoritePin("non-existent");
+
+      const favorites = store.getState().favorites;
+      expect(favorites).toHaveLength(1);
+      expect(favorites[0].id).toBe("fav-1");
+    });
+  });
+
+  describe("moveFavorite", () => {
+    it("moves a favorite up when direction is 'up'", () => {
+      const item1: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+      };
+      const item2: FavoritesItem = {
+        id: "fav-2",
+        mode: "mtr",
+        title: "Admiralty",
+        line: "TWL",
+        sta: "ADM",
+      };
+
+      store.getState().addFavorite(item1);
+      store.getState().addFavorite(item2);
+
+      store.getState().moveFavorite("fav-2", "up");
+
+      const favorites = store.getState().favorites;
+      expect(favorites[0].id).toBe("fav-2");
+      expect(favorites[1].id).toBe("fav-1");
+    });
+
+    it("moves a favorite down when direction is 'down'", () => {
+      const item1: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+      };
+      const item2: FavoritesItem = {
+        id: "fav-2",
+        mode: "mtr",
+        title: "Admiralty",
+        line: "TWL",
+        sta: "ADM",
+      };
+
+      store.getState().addFavorite(item1);
+      store.getState().addFavorite(item2);
+
+      store.getState().moveFavorite("fav-1", "down");
+
+      const favorites = store.getState().favorites;
+      expect(favorites[0].id).toBe("fav-2");
+      expect(favorites[1].id).toBe("fav-1");
+    });
+
+    it("does not move up when already at the top", () => {
+      const item: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+      };
+
+      store.getState().addFavorite(item);
+      store.getState().moveFavorite("fav-1", "up");
+
+      const favorites = store.getState().favorites;
+      expect(favorites).toHaveLength(1);
+      expect(favorites[0].id).toBe("fav-1");
+    });
+
+    it("does not move down when already at the bottom", () => {
+      const item: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+      };
+
+      store.getState().addFavorite(item);
+      store.getState().moveFavorite("fav-1", "down");
+
+      const favorites = store.getState().favorites;
+      expect(favorites).toHaveLength(1);
+      expect(favorites[0].id).toBe("fav-1");
+    });
+
+    it("does not move between pinned and unpinned items", () => {
+      const pinnedItem: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+        pinned: true,
+      };
+      const unpinnedItem: FavoritesItem = {
+        id: "fav-2",
+        mode: "mtr",
+        title: "Admiralty",
+        line: "TWL",
+        sta: "ADM",
+        pinned: false,
+      };
+
+      // addFavorite prepends, so order is: unpinnedItem, pinnedItem
+      store.getState().addFavorite(pinnedItem);
+      store.getState().addFavorite(unpinnedItem);
+
+      // Try to move unpinned item (fav-2) up to pinned position
+      store.getState().moveFavorite("fav-2", "up");
+
+      const favorites = store.getState().favorites;
+      // Order should remain unchanged since pinned status differs
+      expect(favorites[0].id).toBe("fav-2");
+      expect(favorites[1].id).toBe("fav-1");
+    });
+
+    it("does nothing for non-existent favorite id", () => {
+      const item: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+      };
+
+      store.getState().addFavorite(item);
+      store.getState().moveFavorite("non-existent", "up");
+
+      const favorites = store.getState().favorites;
+      expect(favorites).toHaveLength(1);
+      expect(favorites[0].id).toBe("fav-1");
+    });
+  });
+
+  describe("addFavoriteGroup", () => {
+    it("adds a new group with trimmed name", () => {
+      store.getState().addFavoriteGroup("  My Group  ");
+
+      const groups = store.getState().favoritesGroups;
+      expect(groups).toHaveLength(1);
+      expect(groups[0].name).toBe("My Group");
+      expect(groups[0].id).toBeDefined();
+    });
+
+    it("does not add group with empty name", () => {
+      store.getState().addFavoriteGroup("   ");
+
+      const groups = store.getState().favoritesGroups;
+      expect(groups).toHaveLength(0);
+    });
+
+    it("does not add group with empty string", () => {
+      store.getState().addFavoriteGroup("");
+
+      const groups = store.getState().favoritesGroups;
+      expect(groups).toHaveLength(0);
+    });
+  });
+
+  describe("deleteFavoriteGroup", () => {
+    it("removes the group from favoritesGroups", () => {
+      store.getState().addFavoriteGroup("Group 1");
+      const groupId = store.getState().favoritesGroups[0].id;
+
+      store.getState().deleteFavoriteGroup(groupId);
+
+      const groups = store.getState().favoritesGroups;
+      expect(groups).toHaveLength(0);
+    });
+
+    it("removes groupId from favorites assigned to that group", () => {
+      store.getState().addFavoriteGroup("My Group");
+      const groupId = store.getState().favoritesGroups[0].id;
+
+      const item: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+        groupId,
+      };
+
+      store.getState().addFavorite(item);
+      store.getState().deleteFavoriteGroup(groupId);
+
+      const favorites = store.getState().favorites;
+      expect(favorites[0].groupId).toBeNull();
+    });
+
+    it("does not affect favorites in other groups", () => {
+      store.getState().addFavoriteGroup("Group 1");
+      store.getState().addFavoriteGroup("Group 2");
+      const groups = store.getState().favoritesGroups;
+      const group1Id = groups[0].id;
+      const group2Id = groups[1].id;
+
+      const item: FavoritesItem = {
+        id: "fav-1",
+        mode: "mtr",
+        title: "Central",
+        line: "TWL",
+        sta: "CEN",
+        groupId: group2Id,
+      };
+
+      store.getState().addFavorite(item);
+      store.getState().deleteFavoriteGroup(group1Id);
+
+      const favorites = store.getState().favorites;
+      expect(favorites[0].groupId).toBe(group2Id);
+    });
+  });
+});
+
+describe("store migration", () => {
+  it("migrates v1 favorites without meta to v2 with default pinned and groupId", () => {
+    // Simulate the migrate function from store.ts
+    const withFavoriteMeta = (item: FavoritesItem): FavoritesItem => ({
+      ...item,
+      pinned: item.pinned ?? false,
+      groupId: item.groupId ?? null,
+    });
+
+    const migrate = (persistedState: unknown) => {
+      const state = persistedState as { favorites?: FavoritesItem[] } | undefined;
+      const favorites = (state?.favorites ?? []).map((favorite) => withFavoriteMeta(favorite));
+
+      return {
+        mode: "kmb" as const,
+        lang: "tc" as const,
+        routeFilterMode: "simple" as const,
+        autoRefreshSeconds: 15,
+        favorites,
+        favoritesGroups: [],
+        recents: [],
+      };
+    };
+
+    const v1State = {
+      favorites: [
+        {
+          id: "fav-1",
+          mode: "mtr" as const,
+          title: "Central",
+          line: "TWL",
+          sta: "CEN",
+          // No pinned or groupId
+        },
+      ],
+    };
+
+    const migrated = migrate(v1State);
+
+    expect(migrated.favorites[0].pinned).toBe(false);
+    expect(migrated.favorites[0].groupId).toBeNull();
+  });
+
+  it("preserves existing pinned and groupId values during migration", () => {
+    const withFavoriteMeta = (item: FavoritesItem): FavoritesItem => ({
+      ...item,
+      pinned: item.pinned ?? false,
+      groupId: item.groupId ?? null,
+    });
+
+    const migrate = (persistedState: unknown) => {
+      const state = persistedState as { favorites?: FavoritesItem[] } | undefined;
+      const favorites = (state?.favorites ?? []).map((favorite) => withFavoriteMeta(favorite));
+
+      return {
+        mode: "kmb" as const,
+        lang: "tc" as const,
+        routeFilterMode: "simple" as const,
+        autoRefreshSeconds: 15,
+        favorites,
+        favoritesGroups: [{ id: "group-1", name: "Work" }],
+        recents: [],
+      };
+    };
+
+    const v1State = {
+      favorites: [
+        {
+          id: "fav-1",
+          mode: "mtr" as const,
+          title: "Central",
+          line: "TWL",
+          sta: "CEN",
+          pinned: true,
+          groupId: "group-1",
+        },
+      ],
+    };
+
+    const migrated = migrate(v1State);
+
+    expect(migrated.favorites[0].pinned).toBe(true);
+    expect(migrated.favorites[0].groupId).toBe("group-1");
+  });
+
+  it("preserves other state fields during migration", () => {
+    const withFavoriteMeta = (item: FavoritesItem): FavoritesItem => ({
+      ...item,
+      pinned: item.pinned ?? false,
+      groupId: item.groupId ?? null,
+    });
+
+    const migrate = (persistedState: unknown) => {
+      const state = persistedState as { 
+        mode?: "kmb" | "mtr" | "lrt";
+        lang?: "en" | "tc" | "sc";
+        routeFilterMode?: "simple" | "advanced";
+        autoRefreshSeconds?: number;
+        favorites?: FavoritesItem[];
+      } | undefined;
+      const favorites = (state?.favorites ?? []).map((favorite) => withFavoriteMeta(favorite));
+
+      return {
+        mode: state?.mode ?? "kmb",
+        lang: state?.lang ?? "tc",
+        routeFilterMode: state?.routeFilterMode ?? "simple",
+        autoRefreshSeconds: state?.autoRefreshSeconds ?? 15,
+        favorites,
+        favoritesGroups: [],
+        recents: [],
+      };
+    };
+
+    const v1State = {
+      mode: "mtr" as const,
+      lang: "en" as const,
+      routeFilterMode: "advanced" as const,
+      autoRefreshSeconds: 30,
+      favorites: [],
+    };
+
+    const migrated = migrate(v1State);
+
+    expect(migrated.mode).toBe("mtr");
+    expect(migrated.lang).toBe("en");
+    expect(migrated.routeFilterMode).toBe("advanced");
+    expect(migrated.autoRefreshSeconds).toBe(30);
+  });
+
+  it("handles undefined persisted state with defaults", () => {
+    const withFavoriteMeta = (item: FavoritesItem): FavoritesItem => ({
+      ...item,
+      pinned: item.pinned ?? false,
+      groupId: item.groupId ?? null,
+    });
+
+    const migrate = (persistedState: unknown) => {
+      const state = persistedState as { favorites?: FavoritesItem[] } | undefined;
+      const favorites = (state?.favorites ?? []).map((favorite) => withFavoriteMeta(favorite));
+
+      return {
+        mode: "kmb" as const,
+        lang: "tc" as const,
+        routeFilterMode: "simple" as const,
+        autoRefreshSeconds: 15,
+        favorites,
+        favoritesGroups: [],
+        recents: [],
+      };
+    };
+
+    const migrated = migrate(undefined);
+
+    expect(migrated.mode).toBe("kmb");
+    expect(migrated.lang).toBe("tc");
+    expect(migrated.routeFilterMode).toBe("simple");
+    expect(migrated.autoRefreshSeconds).toBe(15);
+    expect(migrated.favorites).toEqual([]);
+    expect(migrated.favoritesGroups).toEqual([]);
+    expect(migrated.recents).toEqual([]);
+  });
+});

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -6,7 +6,12 @@ import { persist } from "zustand/middleware";
 
 export type RouteFilterMode = "simple" | "advanced";
 
-export type FavoritesItem =
+type FavoritesMeta = {
+  pinned?: boolean;
+  groupId?: string | null;
+};
+
+export type FavoritesItem = FavoritesMeta & (
   // KMB: single stop
   | {
       id: string;
@@ -59,10 +64,16 @@ export type FavoritesItem =
       mode: "lrt";
       title: string;
       stationId: string;
-    };
+    }
+);
 
 export type RecentItem = FavoritesItem & {
   at: number;
+};
+
+export type FavoritesGroup = {
+  id: string;
+  name: string;
 };
 
 type AppState = {
@@ -72,6 +83,7 @@ type AppState = {
   autoRefreshSeconds: number;
 
   favorites: FavoritesItem[];
+  favoritesGroups: FavoritesGroup[];
   recents: RecentItem[];
 
   setMode: (mode: TransportMode) => void;
@@ -80,12 +92,31 @@ type AppState = {
   setAutoRefreshSeconds: (seconds: number) => void;
   addFavorite: (item: FavoritesItem) => void;
   removeFavorite: (id: string) => void;
+  toggleFavoritePin: (id: string) => void;
+  moveFavorite: (id: string, direction: "up" | "down") => void;
+  addFavoriteGroup: (name: string) => void;
+  renameFavoriteGroup: (id: string, name: string) => void;
+  deleteFavoriteGroup: (id: string) => void;
+  assignFavoriteGroup: (favoriteId: string, groupId: string | null) => void;
 
   addRecent: (item: FavoritesItem) => void;
   clearRecents: () => void;
 };
 
 const RECENTS_LIMIT = 12;
+
+const createId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 10);
+};
+
+const withFavoriteMeta = (item: FavoritesItem): FavoritesItem => ({
+  ...item,
+  pinned: item.pinned ?? false,
+  groupId: item.groupId ?? null,
+});
 
 export const useAppStore = create<AppState>()(
   persist(
@@ -96,6 +127,7 @@ export const useAppStore = create<AppState>()(
       autoRefreshSeconds: 15,
 
       favorites: [],
+      favoritesGroups: [],
       recents: [],
 
       setMode: (mode) => set({ mode }),
@@ -106,12 +138,89 @@ export const useAppStore = create<AppState>()(
       addFavorite: (item) =>
         set((state) => {
           if (state.favorites.some((f) => f.id === item.id)) return state;
-          return { favorites: [item, ...state.favorites] };
+          return { favorites: [withFavoriteMeta(item), ...state.favorites] };
         }),
 
       removeFavorite: (id) =>
         set((state) => ({
           favorites: state.favorites.filter((f) => f.id !== id),
+        })),
+
+      toggleFavoritePin: (id) =>
+        set((state) => {
+          const favorites = [...state.favorites];
+          const index = favorites.findIndex((f) => f.id === id);
+          if (index === -1) return state;
+
+          const current = favorites[index];
+          const nextPinned = !current.pinned;
+          const updated = { ...current, pinned: nextPinned };
+          favorites.splice(index, 1);
+
+          if (nextPinned) {
+            favorites.unshift(updated);
+          } else {
+            let insertIndex = 0;
+            while (insertIndex < favorites.length && favorites[insertIndex].pinned) {
+              insertIndex += 1;
+            }
+            favorites.splice(insertIndex, 0, updated);
+          }
+
+          return { favorites };
+        }),
+
+      moveFavorite: (id, direction) =>
+        set((state) => {
+          const favorites = [...state.favorites];
+          const index = favorites.findIndex((f) => f.id === id);
+          if (index === -1) return state;
+
+          const targetIndex = direction === "up" ? index - 1 : index + 1;
+          if (targetIndex < 0 || targetIndex >= favorites.length) return state;
+          if (Boolean(favorites[index].pinned) !== Boolean(favorites[targetIndex].pinned)) {
+            return state;
+          }
+
+          const [moved] = favorites.splice(index, 1);
+          favorites.splice(targetIndex, 0, moved);
+          return { favorites };
+        }),
+
+      addFavoriteGroup: (name) =>
+        set((state) => {
+          const trimmed = name.trim();
+          if (!trimmed) return state;
+          const group: FavoritesGroup = { id: createId(), name: trimmed };
+          return { favoritesGroups: [...state.favoritesGroups, group] };
+        }),
+
+      renameFavoriteGroup: (id, name) =>
+        set((state) => {
+          const trimmed = name.trim();
+          if (!trimmed) return state;
+          return {
+            favoritesGroups: state.favoritesGroups.map((group) =>
+              group.id === id ? { ...group, name: trimmed } : group
+            ),
+          };
+        }),
+
+      deleteFavoriteGroup: (id) =>
+        set((state) => ({
+          favorites: state.favorites.map((favorite) =>
+            favorite.groupId === id ? { ...favorite, groupId: null } : favorite
+          ),
+          favoritesGroups: state.favoritesGroups.filter((group) => group.id !== id),
+        })),
+
+      assignFavoriteGroup: (favoriteId, groupId) =>
+        set((state) => ({
+          favorites: state.favorites.map((favorite) =>
+            favorite.id === favoriteId
+              ? { ...favorite, groupId: groupId ?? null }
+              : favorite
+          ),
         })),
 
       addRecent: (item) =>
@@ -131,12 +240,30 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: "hk-eta",
+      version: 2,
+      migrate: (persistedState) => {
+        const state = persistedState as Partial<AppState> | undefined;
+        const favorites = (state?.favorites ?? []).map((favorite) =>
+          withFavoriteMeta(favorite)
+        );
+
+        return {
+          mode: state?.mode ?? "kmb",
+          lang: state?.lang ?? "tc",
+          routeFilterMode: state?.routeFilterMode ?? "simple",
+          autoRefreshSeconds: state?.autoRefreshSeconds ?? 15,
+          favorites,
+          favoritesGroups: state?.favoritesGroups ?? [],
+          recents: state?.recents ?? [],
+        };
+      },
       partialize: (state) => ({
         mode: state.mode,
         lang: state.lang,
         routeFilterMode: state.routeFilterMode,
         autoRefreshSeconds: state.autoRefreshSeconds,
         favorites: state.favorites,
+        favoritesGroups: state.favoritesGroups,
         recents: state.recents,
       }),
     }

--- a/mtr-system-map.json
+++ b/mtr-system-map.json
@@ -1,0 +1,287 @@
+{
+  "system": "Hong Kong MTR",
+  "lines": [
+    {
+      "id": "TWL",
+      "name": "Tsuen Wan Line",
+      "color": "#E60012",
+      "loop": false,
+      "stations": [
+        "Tsuen Wan",
+        "Tai Wo Hau",
+        "Kwai Hing",
+        "Kwai Fong",
+        "Lai King",
+        "Mei Foo",
+        "Lai Chi Kok",
+        "Cheung Sha Wan",
+        "Sham Shui Po",
+        "Prince Edward",
+        "Mong Kok",
+        "Yau Ma Tei",
+        "Jordan",
+        "Tsim Sha Tsui",
+        "Admiralty",
+        "Central"
+      ]
+    },
+    {
+      "id": "ISL",
+      "name": "Island Line",
+      "color": "#0072CE",
+      "loop": false,
+      "stations": [
+        "Kennedy Town",
+        "HKU",
+        "Sai Ying Pun",
+        "Sheung Wan",
+        "Central",
+        "Admiralty",
+        "Wan Chai",
+        "Causeway Bay",
+        "Tin Hau",
+        "Fortress Hill",
+        "North Point",
+        "Quarry Bay",
+        "Tai Koo",
+        "Sai Wan Ho",
+        "Shau Kei Wan",
+        "Heng Fa Chuen",
+        "Chai Wan"
+      ]
+    },
+    {
+      "id": "KTL",
+      "name": "Kwun Tong Line",
+      "color": "#00A651",
+      "loop": false,
+      "stations": [
+        "Whampoa",
+        "Ho Man Tin",
+        "Yau Ma Tei",
+        "Mong Kok",
+        "Prince Edward",
+        "Shek Kip Mei",
+        "Kowloon Tong",
+        "Lok Fu",
+        "Wong Tai Sin",
+        "Diamond Hill",
+        "Choi Hung",
+        "Kowloon Bay",
+        "Ngau Tau Kok",
+        "Kwun Tong",
+        "Lam Tin",
+        "Yau Tong",
+        "Tiu Keng Leng"
+      ]
+    },
+    {
+      "id": "TKL",
+      "name": "Tseung Kwan O Line",
+      "color": "#6A1B9A",
+      "loop": false,
+      "stations": [
+        "North Point",
+        "Quarry Bay",
+        "Yau Tong",
+        "Tiu Keng Leng",
+        "Tseung Kwan O",
+        "Hang Hau",
+        "Po Lam",
+        "LOHAS Park"
+      ]
+    },
+    {
+      "id": "TML",
+      "name": "Tuen Ma Line",
+      "color": "#8B4513",
+      "loop": false,
+      "stations": [
+        "Tuen Mun",
+        "Siu Hong",
+        "Tin Shui Wai",
+        "Long Ping",
+        "Yuen Long",
+        "Kam Sheung Road",
+        "Tsuen Wan West",
+        "Mei Foo",
+        "Nam Cheong",
+        "Austin",
+        "East Tsim Sha Tsui",
+        "Hung Hom",
+        "Ho Man Tin",
+        "To Kwa Wan",
+        "Sung Wong Toi",
+        "Kai Tak",
+        "Diamond Hill",
+        "Hin Keng",
+        "Tai Wai",
+        "Che Kung Temple",
+        "Sha Tin Wai",
+        "City One",
+        "Shek Mun",
+        "Tai Shui Hang",
+        "Heng On",
+        "Ma On Shan",
+        "Wu Kai Sha"
+      ]
+    },
+    {
+      "id": "TKL-Branch",
+      "name": "LOHAS Park Branch",
+      "color": "#6A1B9A",
+      "loop": false,
+      "stations": ["Tseung Kwan O", "LOHAS Park"]
+    },
+    {
+      "id": "EAL",
+      "name": "East Rail Line",
+      "color": "#5BC2E7",
+      "loop": false,
+      "stations": [
+        "Admiralty",
+        "Exhibition Centre",
+        "Hung Hom",
+        "Mong Kok East",
+        "Kowloon Tong",
+        "Tai Wai",
+        "Sha Tin",
+        "Fo Tan",
+        "Racecourse",
+        "University",
+        "Tai Po Market",
+        "Tai Wo",
+        "Fanling",
+        "Sheung Shui",
+        "Lo Wu",
+        "Lok Ma Chau"
+      ]
+    },
+    {
+      "id": "DRL",
+      "name": "Disneyland Resort Line",
+      "color": "#FF69B4",
+      "loop": false,
+      "stations": ["Sunny Bay", "Disneyland Resort"]
+    },
+    {
+      "id": "TCL",
+      "name": "Tung Chung Line",
+      "color": "#F5A623",
+      "loop": false,
+      "stations": [
+        "Hong Kong",
+        "Kowloon",
+        "Olympic",
+        "Nam Cheong",
+        "Lai King",
+        "Tsing Yi",
+        "Sunny Bay",
+        "Tung Chung"
+      ]
+    },
+    {
+      "id": "AEL",
+      "name": "Airport Express",
+      "color": "#00888A",
+      "loop": false,
+      "stations": [
+        "Hong Kong",
+        "Kowloon",
+        "Tsing Yi",
+        "Airport",
+        "AsiaWorld-Expo"
+      ]
+    },
+    {
+      "id": "SIL",
+      "name": "South Island Line",
+      "color": "#B5BD00",
+      "loop": false,
+      "stations": [
+        "Admiralty",
+        "Ocean Park",
+        "Wong Chuk Hang",
+        "Lei Tung",
+        "South Horizons"
+      ]
+    },
+    {
+      "id": "EAL",
+      "name": "East Rail Line",
+      "color": "#5BC2E7",
+      "type": "branched",
+      "trunk": [
+        "Admiralty",
+        "Exhibition Centre",
+        "Hung Hom",
+        "Mong Kok East",
+        "Kowloon Tong",
+        "Tai Wai",
+        "Sha Tin"
+      ],
+      "branches": [
+        {
+          "id": "EAL_MAIN",
+          "from": "Sha Tin",
+          "sequence": [
+            "Fo Tan",
+            "Racecourse (bypass)",
+            "University",
+            "Tai Po Market",
+            "Tai Wo",
+            "Fanling",
+            "Sheung Shui"
+          ],
+          "notes": "Fo Tan is the regular stop. Racecourse is normally bypassed."
+        },
+        {
+          "id": "EAL_RACE_DAY",
+          "from": "Sha Tin",
+          "sequence": ["Racecourse", "University"],
+          "operational": "race_days_only",
+          "notes": "Special race-day routing between Sha Tin and University."
+        },
+        {
+          "id": "EAL_BORDER_SPLIT",
+          "from": "Sheung Shui",
+          "branches": [
+            {
+              "id": "EAL_LO_WU",
+              "sequence": ["Lo Wu"]
+            },
+            {
+              "id": "EAL_LOK_MA_CHAU",
+              "sequence": ["Lok Ma Chau"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TKL",
+      "name": "Tseung Kwan O Line",
+      "color": "#6A1B9A",
+      "type": "branched",
+      "trunk": [
+        "North Point",
+        "Quarry Bay",
+        "Yau Tong",
+        "Tiu Keng Leng",
+        "Tseung Kwan O"
+      ],
+      "branches": [
+        {
+          "id": "TKL_PO_LAM",
+          "from": "Tseung Kwan O",
+          "sequence": ["Hang Hau", "Po Lam"]
+        },
+        {
+          "id": "TKL_LOHAS",
+          "from": "Tseung Kwan O",
+          "sequence": ["LOHAS Park"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- extend favorites storage with pin state and group metadata plus migration
- add pin/unpin and move up/down controls that respect pinned blocks
- add group management and assignment dropdowns in favorites UI