### PR TITLE
feat(geolocation): Add nearby stops with geolocation support

### DIFF
--- a/components/eta/nearby-stops-button.tsx
+++ b/components/eta/nearby-stops-button.tsx
@@ -23,8 +23,19 @@ export function NearbyStopsButton({
   disabled,
   onNearbyStops,
 }: NearbyStopsButtonProps) {
-  const { loading, requestLocation } = useGeolocation();
-  const [hasRequested, setHasRequested] = React.useState(false);
+  const { loading, error, requestLocation } = useGeolocation();
+
+  React.useEffect(() => {
+    if (error) {
+      toast.error(
+        lang === "en"
+          ? error
+          : lang === "sc"
+            ? `定位失败: ${error}`
+            : `定位失敗: ${error}`,
+      );
+    }
+  }, [error, lang]);
 
   const handleClick = React.useCallback(async () => {
     if (stops.length === 0) {
@@ -33,12 +44,10 @@ export function NearbyStopsButton({
           ? "Stop data not loaded yet"
           : lang === "sc"
             ? "车站数据未加载"
-            : "車站數據未載入"
+            : "車站數據未載入",
       );
       return;
     }
-
-    setHasRequested(true);
 
     const loc = await requestLocation();
 
@@ -53,7 +62,7 @@ export function NearbyStopsButton({
       {
         maxDistanceMeters: 300,
         maxGroups: 5,
-      }
+      },
     );
 
     if (nearbyStopIds.length === 0) {
@@ -62,7 +71,7 @@ export function NearbyStopsButton({
           ? "No nearby stops found within 300m"
           : lang === "sc"
             ? "300米内未找到附近车站"
-            : "300米內未找到附近車站"
+            : "300米內未找到附近車站",
       );
       return;
     }
@@ -70,18 +79,7 @@ export function NearbyStopsButton({
     onNearbyStops(nearbyStopIds);
   }, [stops, lang, onNearbyStops, requestLocation]);
 
-  React.useEffect(() => {
-    if (hasRequested) {
-      setHasRequested(false);
-    }
-  }, [hasRequested]);
-
-  const label =
-    lang === "en"
-      ? "Nearby"
-      : lang === "sc"
-        ? "附近"
-        : "附近";
+  const label = lang === "en" ? "Nearby" : lang === "sc" ? "附近" : "附近";
 
   return (
     <Button
@@ -91,9 +89,7 @@ export function NearbyStopsButton({
       disabled={disabled || loading || stops.length === 0}
       onClick={handleClick}
     >
-      <MapPin
-        className={cn("mr-2 h-4 w-4", loading && "animate-pulse")}
-      />
+      <MapPin className={cn("mr-2 h-4 w-4", loading && "animate-pulse")} />
       {loading
         ? lang === "en"
           ? "Locating..."

--- a/components/eta/nearby-stops-button.tsx
+++ b/components/eta/nearby-stops-button.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { MapPin } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { useGeolocation } from "@/lib/eta/use-geolocation";
+import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
+import { findNearbyStopIds } from "@/lib/eta/nearby-stops";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+type NearbyStopsButtonProps = {
+  lang: UiLanguage;
+  stops: KmbStopSearchItem[];
+  disabled?: boolean;
+  onNearbyStops: (stopIds: string[]) => void;
+};
+
+export function NearbyStopsButton({
+  lang,
+  stops,
+  disabled,
+  onNearbyStops,
+}: NearbyStopsButtonProps) {
+  const { loading, requestLocation } = useGeolocation();
+  const [hasRequested, setHasRequested] = React.useState(false);
+
+  const handleClick = React.useCallback(async () => {
+    if (stops.length === 0) {
+      toast.error(
+        lang === "en"
+          ? "Stop data not loaded yet"
+          : lang === "sc"
+            ? "车站数据未加载"
+            : "車站數據未載入"
+      );
+      return;
+    }
+
+    setHasRequested(true);
+
+    const loc = await requestLocation();
+
+    if (!loc) {
+      return;
+    }
+
+    const nearbyStopIds = findNearbyStopIds(
+      stops,
+      { lat: loc.lat, lng: loc.lng },
+      lang,
+      {
+        maxDistanceMeters: 300,
+        maxGroups: 5,
+      }
+    );
+
+    if (nearbyStopIds.length === 0) {
+      toast.info(
+        lang === "en"
+          ? "No nearby stops found within 300m"
+          : lang === "sc"
+            ? "300米内未找到附近车站"
+            : "300米內未找到附近車站"
+      );
+      return;
+    }
+
+    onNearbyStops(nearbyStopIds);
+  }, [stops, lang, onNearbyStops, requestLocation]);
+
+  React.useEffect(() => {
+    if (hasRequested) {
+      setHasRequested(false);
+    }
+  }, [hasRequested]);
+
+  const label =
+    lang === "en"
+      ? "Nearby"
+      : lang === "sc"
+        ? "附近"
+        : "附近";
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className={cn("rounded-xl", disabled && "opacity-50")}
+      disabled={disabled || loading || stops.length === 0}
+      onClick={handleClick}
+    >
+      <MapPin
+        className={cn("mr-2 h-4 w-4", loading && "animate-pulse")}
+      />
+      {loading
+        ? lang === "en"
+          ? "Locating..."
+          : lang === "sc"
+            ? "定位中..."
+            : "定位中..."
+        : label}
+    </Button>
+  );
+}

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -1743,60 +1743,63 @@ export function KmbPane({
 
   return (
     <div className="space-y-4">
-      <StopSearch
-        lang={lang}
-        stops={kmbStops}
-        value={kmbDraftStopSelection}
-        onSelectStop={(stop) => {
-          setKmbDraftStopSelection({ type: "stop", stopId: stop.stopId });
-          onAddRecent({
-            id: `kmb:${stop.stopId}:__stop__`,
-            mode: "kmb",
-            title: pickKmbStopTitle(stop, lang),
-            stopId: stop.stopId,
-          });
-        }}
-        onSelectStops={(stops) => {
-          const stopIds = stops.map((s) => s.stopId);
-          setKmbDraftStopSelection({ type: "stops", stopIds });
-          if (stops.length > 0) {
-            const firstStop = stops[0]!;
-            const fullName = pickKmbStopTitle(firstStop, lang);
-            const { name } = parseKmbStopName(fullName);
-            const firstStopId = stopIds[0]!;
-            onAddRecent({
-              id: `kmb:${stopIds.join(",")}:__stops__`,
-              mode: "kmb",
-              title: name,
-              stopId: firstStopId,
-            });
-          }
-        }}
-        onSelectContains={(query) => {
-          setKmbDraftStopSelection({ type: "contains", query });
-        }}
-      />
-
-      <NearbyStopsButton
-        lang={lang}
-        stops={kmbStops}
-        disabled={loadingStops || kmbStops.length === 0}
-        onNearbyStops={(stopIds) => {
-          if (stopIds.length === 0) return;
-          setKmbDraftStopSelection({ type: "stops", stopIds });
-          const firstStop = kmbStopsById.get(stopIds[0]);
-          if (firstStop) {
-            const fullName = pickKmbStopTitle(firstStop, lang);
-            const { name } = parseKmbStopName(fullName);
-            onAddRecent({
-              id: `kmb:nearby:${stopIds.join(",")}`,
-              mode: "kmb",
-              title: lang === "en" ? `Nearby: ${name}` : `附近: ${name}`,
-              stopId: stopIds[0]!,
-            });
-          }
-        }}
-      />
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0">
+          <StopSearch
+            lang={lang}
+            stops={kmbStops}
+            value={kmbDraftStopSelection}
+            onSelectStop={(stop) => {
+              setKmbDraftStopSelection({ type: "stop", stopId: stop.stopId });
+              onAddRecent({
+                id: `kmb:${stop.stopId}:__stop__`,
+                mode: "kmb",
+                title: pickKmbStopTitle(stop, lang),
+                stopId: stop.stopId,
+              });
+            }}
+            onSelectStops={(stops) => {
+              const stopIds = stops.map((s) => s.stopId);
+              setKmbDraftStopSelection({ type: "stops", stopIds });
+              if (stops.length > 0) {
+                const firstStop = stops[0]!;
+                const fullName = pickKmbStopTitle(firstStop, lang);
+                const { name } = parseKmbStopName(fullName);
+                const firstStopId = stopIds[0]!;
+                onAddRecent({
+                  id: `kmb:${stopIds.join(",")}:__stops__`,
+                  mode: "kmb",
+                  title: name,
+                  stopId: firstStopId,
+                });
+              }
+            }}
+            onSelectContains={(query) => {
+              setKmbDraftStopSelection({ type: "contains", query });
+            }}
+          />
+        </div>
+        <NearbyStopsButton
+          lang={lang}
+          stops={kmbStops}
+          disabled={loadingStops || kmbStops.length === 0}
+          onNearbyStops={(stopIds) => {
+            if (stopIds.length === 0) return;
+            setKmbDraftStopSelection({ type: "stops", stopIds });
+            const firstStop = kmbStopsById.get(stopIds[0]);
+            if (firstStop) {
+              const fullName = pickKmbStopTitle(firstStop, lang);
+              const { name } = parseKmbStopName(fullName);
+              onAddRecent({
+                id: `kmb:nearby:${stopIds.join(",")}`,
+                mode: "kmb",
+                title: lang === "en" ? `Nearby: ${name}` : `附近: ${name}`,
+                stopId: stopIds[0]!,
+              });
+            }
+          }}
+        />
+      </div>
 
       {isMobile ? (
         <div className="space-y-2">

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -9,7 +9,11 @@ import {
   type RouteFilterOption,
   type RouteFilterState,
 } from "@/components/eta/route-filter";
-import { StopSearch, type StopSearchSelection } from "@/components/eta/stop-search";
+import {
+  StopSearch,
+  type StopSearchSelection,
+} from "@/components/eta/stop-search";
+import { NearbyStopsButton } from "@/components/eta/nearby-stops-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -28,7 +32,10 @@ import { isStaleByFlagOrAge } from "@/lib/eta/stale";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
 import type { Company } from "hk-bus-eta";
-import { useInfiniteScroll, useVisibleItems } from "@/lib/eta/use-infinite-scroll";
+import {
+  useInfiniteScroll,
+  useVisibleItems,
+} from "@/lib/eta/use-infinite-scroll";
 import { useMediaQuery } from "@/lib/hooks/use-media-query";
 import { cn } from "@/lib/utils";
 import type { FavoritesItem, RouteFilterMode } from "@/lib/store";
@@ -40,7 +47,10 @@ import type { FavoritesItem, RouteFilterMode } from "@/lib/store";
 type EtaState = {
   byStopId: Record<string, KmbEtaEntryWithLeg[]>;
   loadedStopIds: string[];
-  faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+  faresByVariantKey: Record<
+    string,
+    { hkd: number; dayCode?: number; source: "hk-bus-eta" }
+  >;
   loading: boolean;
   error: string | null;
   stale: boolean;
@@ -55,8 +65,14 @@ type EtaAction =
       payload: {
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         loadedStopIds: string[];
-        faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
-        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
+        faresByVariantKey?: Record<
+          string,
+          { hkd: number; dayCode?: number; source: "hk-bus-eta" }
+        >;
+        staleByStopId?: Record<
+          string,
+          { stale: boolean; ageMs: number | null }
+        >;
       };
     }
   | { type: "REFRESH_ERROR"; error: string }
@@ -65,14 +81,23 @@ type EtaAction =
       payload: {
         byStopId: Record<string, KmbEtaEntryWithLeg[]>;
         newStopIds: string[];
-        faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
-        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>;
+        faresByVariantKey?: Record<
+          string,
+          { hkd: number; dayCode?: number; source: "hk-bus-eta" }
+        >;
+        staleByStopId?: Record<
+          string,
+          { stale: boolean; ageMs: number | null }
+        >;
       };
     }
   | {
       type: "FARES_SUCCESS";
       payload: {
-        faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+        faresByVariantKey: Record<
+          string,
+          { hkd: number; dayCode?: number; source: "hk-bus-eta" }
+        >;
       };
     }
   | { type: "RESET" };
@@ -98,12 +123,15 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         byStopId: action.payload.byStopId,
         loadedStopIds: action.payload.loadedStopIds,
         // Keep existing fares if payload doesn't include new ones (deferred loading)
-        faresByVariantKey: action.payload.faresByVariantKey ?? state.faresByVariantKey,
+        faresByVariantKey:
+          action.payload.faresByVariantKey ?? state.faresByVariantKey,
         loading: false,
         error: null,
         stale: Boolean(
           action.payload.staleByStopId &&
-            Object.values(action.payload.staleByStopId).some((entry) => entry.stale)
+          Object.values(action.payload.staleByStopId).some(
+            (entry) => entry.stale,
+          ),
         ),
         staleByStopId: action.payload.staleByStopId ?? {},
         lastUpdatedAt: Date.now(),
@@ -121,14 +149,23 @@ function etaReducer(state: EtaState, action: EtaAction): EtaState {
         ...state,
         byStopId: { ...state.byStopId, ...action.payload.byStopId },
         loadedStopIds: [...state.loadedStopIds, ...action.payload.newStopIds],
-        faresByVariantKey: { ...state.faresByVariantKey, ...(action.payload.faresByVariantKey ?? {}) },
+        faresByVariantKey: {
+          ...state.faresByVariantKey,
+          ...(action.payload.faresByVariantKey ?? {}),
+        },
         loading: false,
-        staleByStopId: { ...state.staleByStopId, ...(action.payload.staleByStopId ?? {}) },
+        staleByStopId: {
+          ...state.staleByStopId,
+          ...(action.payload.staleByStopId ?? {}),
+        },
       };
     case "FARES_SUCCESS":
       return {
         ...state,
-        faresByVariantKey: { ...state.faresByVariantKey, ...action.payload.faresByVariantKey },
+        faresByVariantKey: {
+          ...state.faresByVariantKey,
+          ...action.payload.faresByVariantKey,
+        },
       };
     case "RESET":
       return initialEtaState;
@@ -160,7 +197,7 @@ function buildStopSearchIndex(stops: KmbStopSearchItem[]): StopSearchIndex {
 function searchStopsByContains(
   stops: KmbStopSearchItem[],
   index: StopSearchIndex,
-  query: string
+  query: string,
 ): string[] {
   const needle = query.trim().toLowerCase();
   if (!needle) return [];
@@ -200,7 +237,10 @@ function buildRouteStopIndex(routeStops: KmbRouteStopLite[]): RouteStopIndex {
   return { byStopId, version: routeStops.length };
 }
 
-function getVariantKeysForStops(index: RouteStopIndex, stopIds: string[]): string[] {
+function getVariantKeysForStops(
+  index: RouteStopIndex,
+  stopIds: string[],
+): string[] {
   const result = new Set<string>();
   for (const stopId of stopIds) {
     const keys = index.byStopId.get(stopId);
@@ -242,7 +282,10 @@ function hasValidEta(items: KmbEtaEntryWithLeg[]): boolean {
 
 function groupEtasByVariant(
   eta: KmbEtaEntryWithLeg[],
-  faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>
+  faresByVariantKey: Record<
+    string,
+    { hkd: number; dayCode?: number; source: "hk-bus-eta" }
+  >,
 ): EtaGroup[] {
   const byVariant = new Map<string, KmbEtaEntryWithLeg[]>();
   for (const entry of eta) {
@@ -262,18 +305,18 @@ function groupEtasByVariant(
   const groups = Array.from(byVariant.entries()).map(([key, items]) => {
     const sorted = [...items].sort((a, b) => a.eta_seq - b.eta_seq);
     const hasEta = hasValidEta(sorted);
-    
+
     // Extract base key (co|route|dir|service_type) for fare lookup
     const parts = key.split("|");
     const baseKey = parts.slice(0, 4).join("|");
     const legPart = parts[4];
     const isArrivingLeg = legPart === "B";
     const [co = "kmb"] = parts;
-    
+
     // hasFare = should show fare badge (true for non-arriving legs)
     // The actual fare may or may not be loaded yet (deferred loading)
     const hasFare = !isArrivingLeg;
-    
+
     return { key, baseKey, items: sorted, hasEta, hasFare, isArrivingLeg };
   });
 
@@ -282,7 +325,7 @@ function groupEtasByVariant(
   // 2) ETA only (hasEta && (!hasFare || fare not loaded))
   // 3) No ETA
   // Within each tier, sort alphabetically by route number
-   const sortByRoute = (a: { key: string }, b: { key: string }) => {
+  const sortByRoute = (a: { key: string }, b: { key: string }) => {
     const [, routeA = ""] = a.key.split("|");
     const [, routeB = ""] = b.key.split("|");
     return routeA.localeCompare(routeB, undefined, { numeric: true });
@@ -308,7 +351,10 @@ function groupEtasByVariant(
 function precomputeRenderGroups(
   etaByStopId: Record<string, KmbEtaEntryWithLeg[]>,
   loadedStopIds: string[],
-  faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>
+  faresByVariantKey: Record<
+    string,
+    { hkd: number; dayCode?: number; source: "hk-bus-eta" }
+  >,
 ): PrecomputedGroups {
   // Precompute groups by stop ID
   const byStopId: Record<string, EtaGroup[]> = {};
@@ -410,7 +456,10 @@ export type KmbPaneState = {
     | { mode: "contains"; query: string }
     | null;
   routeInfos: Record<string, KmbRouteInfoLite>;
-  faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: "hk-bus-eta" }>;
+  faresByVariantKey: Record<
+    string,
+    { hkd: number; dayCode?: number; source: "hk-bus-eta" }
+  >;
   eta: KmbEtaEntryWithLeg[];
   /** ETAs grouped by stop ID for sectioned rendering */
   etaByStopId: Record<string, KmbEtaEntryWithLeg[]>;
@@ -461,11 +510,17 @@ export function KmbPane({
     return new Map(kmbStops.map((stop) => [stop.stopId, stop]));
   }, [kmbStops]);
 
-  const [kmbRouteStops, setKmbRouteStops] = React.useState<KmbRouteStopLite[]>([]);
+  const [kmbRouteStops, setKmbRouteStops] = React.useState<KmbRouteStopLite[]>(
+    [],
+  );
   const [loadingRouteStops, setLoadingRouteStops] = React.useState(false);
-  const [routeStopsError, setRouteStopsError] = React.useState<string | null>(null);
+  const [routeStopsError, setRouteStopsError] = React.useState<string | null>(
+    null,
+  );
 
-  const [kmbRouteInfos, setKmbRouteInfos] = React.useState<Record<string, KmbRouteInfoLite>>({});
+  const [kmbRouteInfos, setKmbRouteInfos] = React.useState<
+    Record<string, KmbRouteInfoLite>
+  >({});
 
   const [kmbDraftStopSelection, setKmbDraftStopSelection] = React.useState<
     StopSearchSelection | undefined
@@ -482,7 +537,7 @@ export function KmbPane({
 
   const activeFilterCount = React.useMemo(
     () => countActiveFilters(routeFilter),
-    [routeFilter]
+    [routeFilter],
   );
 
   // ========== OPTIMIZATION: Use reducer for batched ETA state updates ==========
@@ -539,7 +594,7 @@ export function KmbPane({
 
       return stopIds;
     },
-    [kmbStops, stopSearchIndex]
+    [kmbStops, stopSearchIndex],
   );
 
   // Compute all stop IDs for the current query (uses cached resolution for contains)
@@ -561,10 +616,8 @@ export function KmbPane({
     rootMargin: "300px",
   });
 
-  const { visibleIds: visibleStopIds, registerRef: registerStopRef } = useVisibleItems(
-    loadedStopIds,
-    { rootMargin: "200px" }
-  );
+  const { visibleIds: visibleStopIds, registerRef: registerStopRef } =
+    useVisibleItems(loadedStopIds, { rootMargin: "200px" });
 
   // Derived flat eta array for backwards compatibility
   const kmbEta = React.useMemo(() => {
@@ -583,7 +636,10 @@ export function KmbPane({
         setKmbStops(stops);
         onStopsChange?.(stops);
       } catch (error) {
-        if (!cancelled) setStopsError(error instanceof Error ? error.message : "Failed to load stops");
+        if (!cancelled)
+          setStopsError(
+            error instanceof Error ? error.message : "Failed to load stops",
+          );
       } finally {
         if (!cancelled) setLoadingStops(false);
       }
@@ -607,7 +663,11 @@ export function KmbPane({
         if (!cancelled) setKmbRouteStops(data);
       } catch (error) {
         if (!cancelled)
-          setRouteStopsError(error instanceof Error ? error.message : "Failed to load route-stop");
+          setRouteStopsError(
+            error instanceof Error
+              ? error.message
+              : "Failed to load route-stop",
+          );
       } finally {
         if (!cancelled) setLoadingRouteStops(false);
       }
@@ -640,7 +700,12 @@ export function KmbPane({
   const pickRouteVariantLabel = React.useCallback(
     (info: KmbRouteInfoLite | undefined) => {
       if (!info) return "";
-      const origin = lang === "en" ? info.origin.en : lang === "sc" ? info.origin.sc : info.origin.tc;
+      const origin =
+        lang === "en"
+          ? info.origin.en
+          : lang === "sc"
+            ? info.origin.sc
+            : info.origin.tc;
       const destination =
         lang === "en"
           ? info.destination.en
@@ -650,7 +715,7 @@ export function KmbPane({
       if (!origin || !destination) return "";
       return `${origin} → ${destination}`;
     },
-    [lang]
+    [lang],
   );
 
   // ========== OPTIMIZATION: Use index for available route variants ==========
@@ -658,7 +723,10 @@ export function KmbPane({
     if (!availableStopIdsForFilter.length) return [];
 
     // Use the route-stop index instead of filtering the entire array
-    const variantKeys = getVariantKeysForStops(routeStopIndex, availableStopIdsForFilter);
+    const variantKeys = getVariantKeysForStops(
+      routeStopIndex,
+      availableStopIdsForFilter,
+    );
 
     return variantKeys
       .map((key) => {
@@ -671,14 +739,22 @@ export function KmbPane({
         };
       })
       .filter((opt) => opt.route);
-  }, [availableStopIdsForFilter, kmbRouteInfos, routeStopIndex, pickRouteVariantLabel]);
+  }, [
+    availableStopIdsForFilter,
+    kmbRouteInfos,
+    routeStopIndex,
+    pickRouteVariantLabel,
+  ]);
 
   React.useEffect(() => {
     if (!availableStopIdsForFilter.length) return;
     if (!routeStopIndex.version) return;
 
     // Use the route-stop index instead of filtering the entire array
-    const variantKeys = getVariantKeysForStops(routeStopIndex, availableStopIdsForFilter);
+    const variantKeys = getVariantKeysForStops(
+      routeStopIndex,
+      availableStopIdsForFilter,
+    );
 
     const missing = variantKeys.filter((key) => !kmbRouteInfos[key]);
     if (!missing.length) return;
@@ -687,10 +763,16 @@ export function KmbPane({
     const load = async () => {
       const fetched = await Promise.allSettled(
         missing.map(async (key) => {
-          const [co = "kmb", route = "", direction = "", serviceType = ""] = key.split("|");
-          const info = await fetchKmbRouteInfo({ co: co as Company, route, direction, serviceType });
+          const [co = "kmb", route = "", direction = "", serviceType = ""] =
+            key.split("|");
+          const info = await fetchKmbRouteInfo({
+            co: co as Company,
+            route,
+            direction,
+            serviceType,
+          });
           return { key, info };
-        })
+        }),
       );
 
       if (cancelled) return;
@@ -717,7 +799,7 @@ export function KmbPane({
     if (!(routeFilter.entries ?? []).length) return;
 
     const nextEntries = (routeFilter.entries ?? []).filter((entry) =>
-      kmbAvailableRouteVariants.some((opt) => opt.key === entry.variantKey)
+      kmbAvailableRouteVariants.some((opt) => opt.key === entry.variantKey),
     );
 
     if (nextEntries.length === (routeFilter.entries ?? []).length) return;
@@ -733,14 +815,17 @@ export function KmbPane({
   // Build route filter string based on current filter state
   const getRouteFilterString = React.useCallback(
     (query: KmbQuery) => {
-      const advancedEntries = routeFilterMode === "advanced" ? (routeFilter.entries ?? []) : [];
-      const requestedRoutes = normalizeKmbRoutesInput(query.route?.trim() ?? "");
+      const advancedEntries =
+        routeFilterMode === "advanced" ? (routeFilter.entries ?? []) : [];
+      const requestedRoutes = normalizeKmbRoutesInput(
+        query.route?.trim() ?? "",
+      );
 
       if (advancedEntries.length) {
         const routesFromAdvanced = new Set(
           advancedEntries
             .map((e) => e.variantKey.split("|")[1])
-            .filter(Boolean)
+            .filter(Boolean),
         );
         return Array.from(routesFromAdvanced).join(",");
       } else if (requestedRoutes) {
@@ -748,7 +833,7 @@ export function KmbPane({
       }
       return undefined;
     },
-    [routeFilter.entries, routeFilterMode]
+    [routeFilter.entries, routeFilterMode],
   );
 
   // Fetch ETAs for a specific set of stop IDs and merge into state
@@ -762,7 +847,7 @@ export function KmbPane({
         append?: boolean;
         mergeExisting?: boolean;
         replaceLoadedStopIds?: string[];
-      }
+      },
     ) => {
       if (!stopIds.length) return;
 
@@ -777,12 +862,13 @@ export function KmbPane({
 
       if (result.truncatedStopIds?.length) {
         console.warn(
-          `KMB ETA truncated ${result.truncatedStopIds.length} stop(s) (limit 100 per request).`
+          `KMB ETA truncated ${result.truncatedStopIds.length} stop(s) (limit 100 per request).`,
         );
       }
 
       // Apply advanced filter client-side if needed
-      const advancedEntries = routeFilterMode === "advanced" ? (routeFilter.entries ?? []) : [];
+      const advancedEntries =
+        routeFilterMode === "advanced" ? (routeFilter.entries ?? []) : [];
       const advancedKeys = advancedEntries.length
         ? new Set(advancedEntries.map((e) => e.variantKey).filter(Boolean))
         : null;
@@ -812,7 +898,7 @@ export function KmbPane({
                   mode: "kmb",
                 }),
               },
-            ])
+            ]),
           )
         : undefined;
 
@@ -849,8 +935,8 @@ export function KmbPane({
 
       // Fire background request for fares
       // Build list of unique variants that need fares
-      const allEtas = Object.entries(filteredByStopId).flatMap(([stopId, etas]) =>
-        etas.map((eta) => ({ stopId, eta }))
+      const allEtas = Object.entries(filteredByStopId).flatMap(
+        ([stopId, etas]) => etas.map((eta) => ({ stopId, eta })),
       );
       const seenVariants = new Set<string>();
       const fareVariants: KmbFareVariant[] = [];
@@ -863,7 +949,8 @@ export function KmbPane({
         const vKey = `${co}|${route}|${dir}|${serviceType}`;
 
         // Skip if we already have this fare or already queued it
-        if (etaState.faresByVariantKey[vKey] || seenVariants.has(vKey)) continue;
+        if (etaState.faresByVariantKey[vKey] || seenVariants.has(vKey))
+          continue;
         seenVariants.add(vKey);
 
         fareVariants.push({
@@ -872,7 +959,9 @@ export function KmbPane({
           dir,
           serviceType,
           stopId,
-          destCandidates: [eta.dest_en, eta.dest_tc, eta.dest_sc].filter(Boolean) as string[],
+          destCandidates: [eta.dest_en, eta.dest_tc, eta.dest_sc].filter(
+            Boolean,
+          ) as string[],
         });
       }
 
@@ -897,14 +986,23 @@ export function KmbPane({
 
       return { filteredByStopId, result };
     },
-    [routeFilter.entries, routeFilterMode, etaState.loadedStopIds, etaState.faresByVariantKey]
+    [
+      routeFilter.entries,
+      routeFilterMode,
+      etaState.loadedStopIds,
+      etaState.faresByVariantKey,
+    ],
   );
 
   // Main refresh function - handles both initial load and refresh of loaded stops
   const refreshKmbEta = React.useCallback(
     async (
       queryOverride?: KmbQuery | null,
-      options?: { toastOnError?: boolean; isInitialLoad?: boolean; isAutoRefresh?: boolean }
+      options?: {
+        toastOnError?: boolean;
+        isInitialLoad?: boolean;
+        isAutoRefresh?: boolean;
+      },
     ) => {
       const query = queryOverride ?? kmbQuery;
       if (!query) return;
@@ -970,26 +1068,42 @@ export function KmbPane({
             new Set(
               allEtas.map(
                 (eta) =>
-                  `${String(eta.co ?? "kmb")}|${(eta.route ?? "").toUpperCase()}|${eta.dir}|${String(eta.service_type)}`
-              )
-            )
+                  `${String(eta.co ?? "kmb")}|${(eta.route ?? "").toUpperCase()}|${eta.dir}|${String(eta.service_type)}`,
+              ),
+            ),
           );
 
           // Use index instead of filtering entire kmbRouteStops array
-          const candidateKeysFromStops = getVariantKeysForStops(routeStopIndex, refreshStopIds);
+          const candidateKeysFromStops = getVariantKeysForStops(
+            routeStopIndex,
+            refreshStopIds,
+          );
 
-          const allVariantKeys = new Set([...variantKeysFromEtas, ...candidateKeysFromStops]);
+          const allVariantKeys = new Set([
+            ...variantKeysFromEtas,
+            ...candidateKeysFromStops,
+          ]);
           const missingKeys = Array.from(allVariantKeys).filter(
-            (key) => !kmbRouteInfos[key]
+            (key) => !kmbRouteInfos[key],
           );
 
           if (missingKeys.length && !controller.signal.aborted) {
             const fetched = await Promise.allSettled(
               missingKeys.slice(0, 30).map(async (key) => {
-                const [co = "kmb", route = "", direction = "", serviceType = ""] = key.split("|");
-                const info = await fetchKmbRouteInfo({ co: co as Company, route, direction, serviceType });
+                const [
+                  co = "kmb",
+                  route = "",
+                  direction = "",
+                  serviceType = "",
+                ] = key.split("|");
+                const info = await fetchKmbRouteInfo({
+                  co: co as Company,
+                  route,
+                  direction,
+                  serviceType,
+                });
                 return { key, info };
-              })
+              }),
             );
 
             if (!controller.signal.aborted) {
@@ -1009,10 +1123,12 @@ export function KmbPane({
         const isAbort =
           controller.signal.aborted ||
           (error instanceof DOMException && error.name === "AbortError") ||
-          (error instanceof Error && error.message.toLowerCase().includes("aborted"));
+          (error instanceof Error &&
+            error.message.toLowerCase().includes("aborted"));
         if (isAbort) return;
 
-        const message = error instanceof Error ? error.message : "Failed to load ETAs";
+        const message =
+          error instanceof Error ? error.message : "Failed to load ETAs";
         dispatchEta({ type: "REFRESH_ERROR", error: message });
 
         if (options?.toastOnError) {
@@ -1031,7 +1147,7 @@ export function KmbPane({
       resolveContainsStopIds,
       routeStopIndex,
       visibleStopIds,
-    ]
+    ],
   );
 
   const loadMoreLoadingRef = React.useRef(false);
@@ -1068,15 +1184,24 @@ export function KmbPane({
       const isAbort =
         controller.signal.aborted ||
         (error instanceof DOMException && error.name === "AbortError") ||
-        (error instanceof Error && error.message.toLowerCase().includes("aborted"));
+        (error instanceof Error &&
+          error.message.toLowerCase().includes("aborted"));
       if (isAbort) return;
 
-      const message = error instanceof Error ? error.message : "Failed to load more stops";
+      const message =
+        error instanceof Error ? error.message : "Failed to load more stops";
       dispatchEta({ type: "REFRESH_ERROR", error: message });
     } finally {
       loadMoreLoadingRef.current = false;
     }
-  }, [kmbQuery, kmbEtaLoading, loadedStopIds, allStopIds, getRouteFilterString, fetchStopEtas]);
+  }, [
+    kmbQuery,
+    kmbEtaLoading,
+    loadedStopIds,
+    allStopIds,
+    getRouteFilterString,
+    fetchStopEtas,
+  ]);
 
   // Watch infinite scroll visibleCount and load more when needed
   const prevVisibleCountRef = React.useRef(infiniteScroll.visibleCount);
@@ -1089,7 +1214,12 @@ export function KmbPane({
     if (curr > prev && curr > loadedStopIds.length && infiniteScroll.hasMore) {
       void loadMoreStops();
     }
-  }, [infiniteScroll.visibleCount, infiniteScroll.hasMore, loadedStopIds.length, loadMoreStops]);
+  }, [
+    infiniteScroll.visibleCount,
+    infiniteScroll.hasMore,
+    loadedStopIds.length,
+    loadMoreStops,
+  ]);
 
   // Cleanup abort controller on unmount
   React.useEffect(() => {
@@ -1108,7 +1238,10 @@ export function KmbPane({
   React.useEffect(() => {
     if (!onRegisterRefresh) return;
     onRegisterRefresh(() =>
-      refreshKmbEtaRef.current(kmbQuery, { toastOnError: false, isAutoRefresh: true })
+      refreshKmbEtaRef.current(kmbQuery, {
+        toastOnError: false,
+        isAutoRefresh: true,
+      }),
     );
   }, [kmbQuery, onRegisterRefresh]);
 
@@ -1123,10 +1256,13 @@ export function KmbPane({
       onRouteFilterModeChange(nextRouteFilterMode);
     }
 
-      const restoredEntries = (selectedItem.entries ?? []).map((entry, idx) => ({
-        id: `restored-${idx}`,
-        variantKey: entry.variantKey.split("|").length === 3 ? `kmb|${entry.variantKey}` : entry.variantKey,
-      }));
+    const restoredEntries = (selectedItem.entries ?? []).map((entry, idx) => ({
+      id: `restored-${idx}`,
+      variantKey:
+        entry.variantKey.split("|").length === 3
+          ? `kmb|${entry.variantKey}`
+          : entry.variantKey,
+    }));
 
     setRouteFilter({
       routes: selectedItem.route ?? "",
@@ -1136,7 +1272,10 @@ export function KmbPane({
     if ("stopId" in selectedItem) {
       setKmbDraftStopSelection({ type: "stop", stopId: selectedItem.stopId });
     } else if ("stopIds" in selectedItem) {
-      setKmbDraftStopSelection({ type: "stops", stopIds: selectedItem.stopIds });
+      setKmbDraftStopSelection({
+        type: "stops",
+        stopIds: selectedItem.stopIds,
+      });
     } else if ("query" in selectedItem) {
       setKmbDraftStopSelection({ type: "contains", query: selectedItem.query });
     }
@@ -1147,7 +1286,9 @@ export function KmbPane({
     infiniteScroll.reset();
   }, [onRouteFilterModeChange, routeFilterMode, selectedItem, infiniteScroll]);
 
-  const prevStopSelectionRef = React.useRef<StopSearchSelection | undefined>(undefined);
+  const prevStopSelectionRef = React.useRef<StopSearchSelection | undefined>(
+    undefined,
+  );
   React.useEffect(() => {
     if (!kmbDraftStopSelection) return;
     if (!kmbRouteStops.length) return;
@@ -1159,18 +1300,24 @@ export function KmbPane({
       prev &&
       prev.type === kmbDraftStopSelection.type &&
       (prev.type === "stop"
-        ? prev.stopId === (kmbDraftStopSelection as { type: "stop"; stopId: string }).stopId
+        ? prev.stopId ===
+          (kmbDraftStopSelection as { type: "stop"; stopId: string }).stopId
         : prev.type === "stops"
-          ? JSON.stringify((prev as { type: "stops"; stopIds: string[] }).stopIds) ===
+          ? JSON.stringify(
+              (prev as { type: "stops"; stopIds: string[] }).stopIds,
+            ) ===
             JSON.stringify(
-              (kmbDraftStopSelection as { type: "stops"; stopIds: string[] }).stopIds
+              (kmbDraftStopSelection as { type: "stops"; stopIds: string[] })
+                .stopIds,
             )
           : (prev as { type: "contains"; query: string }).query ===
-            (kmbDraftStopSelection as { type: "contains"; query: string }).query);
+            (kmbDraftStopSelection as { type: "contains"; query: string })
+              .query);
 
     if (isSame) return;
 
-    const routeInput = routeFilterMode === "simple" ? routeFilter.routes?.trim() ?? "" : "";
+    const routeInput =
+      routeFilterMode === "simple" ? (routeFilter.routes?.trim() ?? "") : "";
     const nextQuery: KmbQuery =
       kmbDraftStopSelection.type === "stop"
         ? {
@@ -1198,8 +1345,17 @@ export function KmbPane({
     infiniteScroll.reset();
 
     setKmbQuery(nextQuery);
-    void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true });
-  }, [kmbDraftStopSelection, kmbRouteStops.length, routeFilter.routes, routeFilterMode, infiniteScroll]);
+    void refreshKmbEtaRef.current(nextQuery, {
+      toastOnError: false,
+      isInitialLoad: true,
+    });
+  }, [
+    kmbDraftStopSelection,
+    kmbRouteStops.length,
+    routeFilter.routes,
+    routeFilterMode,
+    infiniteScroll,
+  ]);
 
   React.useEffect(() => {
     if (!selectedItem) return;
@@ -1234,7 +1390,10 @@ export function KmbPane({
     if (!nextQuery) return;
 
     setKmbQuery(nextQuery);
-    void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true });
+    void refreshKmbEtaRef.current(nextQuery, {
+      toastOnError: false,
+      isInitialLoad: true,
+    });
   }, [selectedItem]);
 
   const prevEntriesRef = React.useRef<typeof routeFilter.entries>([]);
@@ -1249,20 +1408,46 @@ export function KmbPane({
 
     const prevKeys = new Set(prev.map((e) => e.variantKey));
     const currKeys = new Set(curr.map((e) => e.variantKey));
-    if (prevKeys.size === currKeys.size && [...prevKeys].every((k) => currKeys.has(k))) return;
+    if (
+      prevKeys.size === currKeys.size &&
+      [...prevKeys].every((k) => currKeys.has(k))
+    )
+      return;
 
     const nextQuery: KmbQuery =
       kmbDraftStopSelection.type === "stop"
-        ? { mode: "stop", stopId: kmbDraftStopSelection.stopId, serviceType: "1" }
+        ? {
+            mode: "stop",
+            stopId: kmbDraftStopSelection.stopId,
+            serviceType: "1",
+          }
         : kmbDraftStopSelection.type === "stops"
-          ? { mode: "stops", stopIds: kmbDraftStopSelection.stopIds, serviceType: "1" }
-          : { mode: "contains", query: kmbDraftStopSelection.query, serviceType: "1" };
+          ? {
+              mode: "stops",
+              stopIds: kmbDraftStopSelection.stopIds,
+              serviceType: "1",
+            }
+          : {
+              mode: "contains",
+              query: kmbDraftStopSelection.query,
+              serviceType: "1",
+            };
 
     setKmbQuery(nextQuery);
-    void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true });
-  }, [routeFilterMode, routeFilter.entries, kmbDraftStopSelection, kmbRouteStops.length]);
+    void refreshKmbEtaRef.current(nextQuery, {
+      toastOnError: false,
+      isInitialLoad: true,
+    });
+  }, [
+    routeFilterMode,
+    routeFilter.entries,
+    kmbDraftStopSelection,
+    kmbRouteStops.length,
+  ]);
 
-  const [debouncedRoutes, setDebouncedRoutes] = React.useState(routeFilter.routes ?? "");
+  const [debouncedRoutes, setDebouncedRoutes] = React.useState(
+    routeFilter.routes ?? "",
+  );
   React.useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedRoutes(routeFilter.routes ?? "");
@@ -1278,19 +1463,47 @@ export function KmbPane({
     const routeInput = debouncedRoutes.trim();
     const nextQuery: KmbQuery =
       kmbDraftStopSelection.type === "stop"
-        ? { mode: "stop", stopId: kmbDraftStopSelection.stopId, route: routeInput || undefined, serviceType: "1" }
+        ? {
+            mode: "stop",
+            stopId: kmbDraftStopSelection.stopId,
+            route: routeInput || undefined,
+            serviceType: "1",
+          }
         : kmbDraftStopSelection.type === "stops"
-          ? { mode: "stops", stopIds: kmbDraftStopSelection.stopIds, route: routeInput || undefined, serviceType: "1" }
-          : { mode: "contains", query: kmbDraftStopSelection.query, route: routeInput || undefined, serviceType: "1" };
+          ? {
+              mode: "stops",
+              stopIds: kmbDraftStopSelection.stopIds,
+              route: routeInput || undefined,
+              serviceType: "1",
+            }
+          : {
+              mode: "contains",
+              query: kmbDraftStopSelection.query,
+              route: routeInput || undefined,
+              serviceType: "1",
+            };
 
     setKmbQuery(nextQuery);
-    void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true });
-  }, [routeFilterMode, debouncedRoutes, kmbDraftStopSelection, kmbRouteStops.length]);
+    void refreshKmbEtaRef.current(nextQuery, {
+      toastOnError: false,
+      isInitialLoad: true,
+    });
+  }, [
+    routeFilterMode,
+    debouncedRoutes,
+    kmbDraftStopSelection,
+    kmbRouteStops.length,
+  ]);
 
   const kmbResultsInfo = React.useMemo(() => {
     if (!kmbQuery) {
       return {
-        title: lang === "en" ? "Bus ETAs" : lang === "sc" ? "巴士到站预报" : "巴士到站預報",
+        title:
+          lang === "en"
+            ? "Bus ETAs"
+            : lang === "sc"
+              ? "巴士到站预报"
+              : "巴士到站預報",
         code: null,
       };
     }
@@ -1312,7 +1525,10 @@ export function KmbPane({
         const parsed = parseKmbStopName(fullName);
         return { title: parsed.name, code: null };
       }
-      return { title: lang === "en" ? "Selected stops" : "已選車站", code: null };
+      return {
+        title: lang === "en" ? "Selected stops" : "已選車站",
+        code: null,
+      };
     }
     return {
       title:
@@ -1328,8 +1544,10 @@ export function KmbPane({
     (kmbQuery?.mode === "stops" && kmbQuery.stopIds.length > 0) ||
     (kmbQuery?.mode === "contains" && kmbQuery.query.trim().length >= 3) ||
     kmbDraftStopSelection?.type === "stop" ||
-    (kmbDraftStopSelection?.type === "stops" && kmbDraftStopSelection.stopIds.length > 0) ||
-    (kmbDraftStopSelection?.type === "contains" && kmbDraftStopSelection.query.trim().length >= 3);
+    (kmbDraftStopSelection?.type === "stops" &&
+      kmbDraftStopSelection.stopIds.length > 0) ||
+    (kmbDraftStopSelection?.type === "contains" &&
+      kmbDraftStopSelection.query.trim().length >= 3);
 
   React.useEffect(() => {
     canFavoriteRef.current = Boolean(canFavorite);
@@ -1357,7 +1575,6 @@ export function KmbPane({
           ? ` · ${route}`
           : "";
 
-
     const stopId =
       kmbQuery?.mode === "stop"
         ? kmbQuery.stopId
@@ -1383,7 +1600,11 @@ export function KmbPane({
 
     if (stopId) {
       const stop = kmbStopsById.get(stopId);
-      const fullName = stop ? pickKmbStopTitle(stop, lang) : lang === "en" ? "Bus" : "巴士";
+      const fullName = stop
+        ? pickKmbStopTitle(stop, lang)
+        : lang === "en"
+          ? "Bus"
+          : "巴士";
       const { name } = parseKmbStopName(fullName);
       const title = `${name}${routeSuffix}`;
 
@@ -1399,8 +1620,12 @@ export function KmbPane({
         entries: entriesForSave,
       };
     } else if (stopIds && stopIds.length > 0) {
-      const firstStop = stopIds.map((stopId) => kmbStopsById.get(stopId)).find(Boolean);
-      const fullName = firstStop ? pickKmbStopTitle(firstStop, lang) : "Selected Stops";
+      const firstStop = stopIds
+        .map((stopId) => kmbStopsById.get(stopId))
+        .find(Boolean);
+      const fullName = firstStop
+        ? pickKmbStopTitle(firstStop, lang)
+        : "Selected Stops";
       const { name } = parseKmbStopName(fullName);
       const title = `${name}${routeSuffix}`;
 
@@ -1439,14 +1664,20 @@ export function KmbPane({
   const isKeyphraseMode = kmbQuery?.mode === "contains";
   const querySummary = React.useMemo<KmbPaneState["querySummary"]>(() => {
     if (!kmbQuery) return null;
-    if (kmbQuery.mode === "stop") return { mode: "stop", stopId: kmbQuery.stopId };
-    if (kmbQuery.mode === "stops") return { mode: "stops", stopIds: kmbQuery.stopIds };
+    if (kmbQuery.mode === "stop")
+      return { mode: "stop", stopId: kmbQuery.stopId };
+    if (kmbQuery.mode === "stops")
+      return { mode: "stops", stopIds: kmbQuery.stopIds };
     return { mode: "contains", query: kmbQuery.query };
   }, [kmbQuery]);
 
   // ========== OPTIMIZATION: Precompute render groups to avoid work during render ==========
   const precomputedGroups = React.useMemo<PrecomputedGroups>(() => {
-    return precomputeRenderGroups(kmbEtaByStopId, loadedStopIds, kmbFaresByVariantKey);
+    return precomputeRenderGroups(
+      kmbEtaByStopId,
+      loadedStopIds,
+      kmbFaresByVariantKey,
+    );
   }, [kmbEtaByStopId, loadedStopIds, kmbFaresByVariantKey]);
 
   const paneState = React.useMemo<KmbPaneState>(
@@ -1465,7 +1696,8 @@ export function KmbPane({
       staleByStopId: kmbEtaStaleByStopId,
       lastUpdatedAt: kmbEtaLastUpdatedAt ?? undefined,
       hasQuery: Boolean(kmbQuery),
-      multipleStops: kmbQuery?.mode === "stops" || kmbQuery?.mode === "contains",
+      multipleStops:
+        kmbQuery?.mode === "stops" || kmbQuery?.mode === "contains",
       isKeyphraseMode: isKeyphraseMode ?? false,
       title: kmbResultsInfo.title,
       stopCode: kmbResultsInfo.code,
@@ -1502,7 +1734,7 @@ export function KmbPane({
       precomputedGroups,
       visibleStopIds,
       registerStopRef,
-    ]
+    ],
   );
 
   React.useEffect(() => {
@@ -1545,6 +1777,27 @@ export function KmbPane({
         }}
       />
 
+      <NearbyStopsButton
+        lang={lang}
+        stops={kmbStops}
+        disabled={loadingStops || kmbStops.length === 0}
+        onNearbyStops={(stopIds) => {
+          if (stopIds.length === 0) return;
+          setKmbDraftStopSelection({ type: "stops", stopIds });
+          const firstStop = kmbStopsById.get(stopIds[0]);
+          if (firstStop) {
+            const fullName = pickKmbStopTitle(firstStop, lang);
+            const { name } = parseKmbStopName(fullName);
+            onAddRecent({
+              id: `kmb:nearby:${stopIds.join(",")}`,
+              mode: "kmb",
+              title: lang === "en" ? `Nearby: ${name}` : `附近: ${name}`,
+              stopId: stopIds[0]!,
+            });
+          }
+        }}
+      />
+
       {isMobile ? (
         <div className="space-y-2">
           <button
@@ -1558,7 +1811,10 @@ export function KmbPane({
                 {lang === "en" ? "Route Filter" : "路線篩選"}
               </span>
               {activeFilterCount > 0 && (
-                <Badge variant="secondary" className="rounded-lg px-2 py-0.5 text-xs">
+                <Badge
+                  variant="secondary"
+                  className="rounded-lg px-2 py-0.5 text-xs"
+                >
                   {activeFilterCount}
                 </Badge>
               )}
@@ -1573,7 +1829,9 @@ export function KmbPane({
           <div
             className={cn(
               "grid transition-all duration-200 ease-in-out",
-              filterExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+              filterExpanded
+                ? "grid-rows-[1fr] opacity-100"
+                : "grid-rows-[0fr] opacity-0",
             )}
           >
             <div className="overflow-hidden">
@@ -1598,7 +1856,6 @@ export function KmbPane({
           onChange={(next) => setRouteFilter(next)}
         />
       )}
-
 
       {stopsError ? (
         <div className="rounded-2xl border bg-background/40 p-3 text-sm text-destructive">
@@ -1631,9 +1888,10 @@ export function KmbPane({
           variant="outline"
           className="rounded-xl"
           onClick={() => void refreshKmbEta(kmbQuery, { toastOnError: true })}
-
         >
-          <RefreshCw className={cn("mr-2 h-4 w-4", kmbEtaLoading && "ui-spin")} />
+          <RefreshCw
+            className={cn("mr-2 h-4 w-4", kmbEtaLoading && "ui-spin")}
+          />
           {lang === "en" ? "Refresh" : "重新整理"}
         </Button>
       </div>
@@ -1649,8 +1907,6 @@ export function KmbPane({
           {lang === "en" ? "Save" : "收藏"}
         </Button>
       </div>
-
-
     </div>
   );
 }

--- a/components/eta/stop-search.tsx
+++ b/components/eta/stop-search.tsx
@@ -12,8 +12,20 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
+import {
+  buildStopComputed,
+  groupStopsByName,
+  areCodesSequential,
+  formatCodeRange,
+  type StopComputed,
+  type StopGroup,
+} from "@/lib/eta/stop-grouping";
 import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
 import { cn } from "@/lib/utils";
 import Fuse from "fuse.js";
@@ -32,192 +44,12 @@ type Props = {
   onSelectContains: (query: string) => void;
 };
 
-type StopComputed = {
-  stopId: string;
-  baseName: string;
-  stopCode: string | null;
-  displaySecondary: string;
-
-  /** Primary display name in selected UI language */
-  displayName: string;
-
-  /** Search fields with better weighting */
-  searchName: string;
-  searchSecondary: string;
-  searchCode: string;
-
-  /** Catch-all fallback for fuzzy matches */
-  normalized: string;
-
-  stop: KmbStopSearchItem;
-};
-
-// --- Utility functions for stop name/code parsing ---
+// --- Utility functions for stop name ---
 
 function formatStopName(stop: KmbStopSearchItem, lang: UiLanguage) {
   if (lang === "sc") return stop.nameSc;
   if (lang === "en") return stop.nameEn;
   return stop.nameTc;
-}
-
-function formatStopSecondary(stop: KmbStopSearchItem, lang: UiLanguage) {
-  if (lang === "en") return stop.nameTc;
-  return stop.nameEn;
-}
-
-
-/**
- * Parse a stop code into prefix and numeric parts.
- * e.g., "KT313" → { prefix: "KT", num: 313 }
- */
-function parseCodeParts(code: string): { prefix: string; num: number } | null {
-  const match = code.match(/^([A-Z]{1,2})(\d+)$/);
-  if (!match) return null;
-  return { prefix: match[1], num: parseInt(match[2], 10) };
-}
-
-/**
- * Check if a set of codes are sequential (same prefix, consecutive numbers).
- */
-function areCodesSequential(codes: string[]): boolean {
-  if (codes.length <= 1) return true;
-  const parsed = codes.map(parseCodeParts).filter(Boolean) as { prefix: string; num: number }[];
-  if (parsed.length !== codes.length) return false;
-
-  const prefix = parsed[0].prefix;
-  if (!parsed.every((p) => p.prefix === prefix)) return false;
-
-  const nums = parsed.map((p) => p.num).sort((a, b) => a - b);
-  for (let i = 1; i < nums.length; i++) {
-    if (nums[i] !== nums[i - 1] + 1) return false;
-  }
-  return true;
-}
-
-/**
- * Format a range of sequential codes.
- * e.g., ["KT313", "KT314", "KT315", "KT316"] → "KT313-KT316"
- */
-function formatCodeRange(codes: string[]): string {
-  if (codes.length === 0) return "";
-  if (codes.length === 1) return codes[0];
-
-  const sorted = [...codes].sort((a, b) => {
-    const pa = parseCodeParts(a);
-    const pb = parseCodeParts(b);
-    if (!pa || !pb) return a.localeCompare(b);
-    return pa.num - pb.num;
-  });
-
-  return `${sorted[0]}-${sorted[sorted.length - 1]}`;
-}
-
-// --- Stop grouping types and logic ---
-
-type StopGroup = {
-  id: string; // Unique key for React
-  baseName: string;
-  codes: string[];
-  stops: KmbStopSearchItem[];
-  displayName: string;
-  displayCodes: string;
-  displaySecondary: string;
-};
-
-/**
- * Group stops by their base name (without code) and merge those with sequential codes.
- * Handles multiple separate sequential sets (e.g., KT313-KT316 AND KT681-KT683).
- * Non-sequential stops remain as individual items.
- */
-function groupStopsByName(stops: StopComputed[]): StopGroup[] {
-  const byBaseName = new Map<string, StopComputed[]>();
-  for (const stop of stops) {
-    const baseName = stop.baseName;
-    if (!byBaseName.has(baseName)) {
-      byBaseName.set(baseName, []);
-    }
-    byBaseName.get(baseName)!.push(stop);
-  }
-
-  const result: StopGroup[] = [];
-
-  for (const [baseName, items] of byBaseName) {
-    const withCodes = items.filter((i) => i.stopCode !== null);
-    const withoutCodes = items.filter((i) => i.stopCode === null);
-
-    withCodes.sort((a, b) => {
-      const pa = parseCodeParts(a.stopCode!);
-      const pb = parseCodeParts(b.stopCode!);
-      if (!pa || !pb) return 0;
-      if (pa.prefix !== pb.prefix) return pa.prefix.localeCompare(pb.prefix);
-      return pa.num - pb.num;
-    });
-
-    const runs: StopComputed[][] = [];
-    for (const item of withCodes) {
-      const lastRun = runs[runs.length - 1];
-      if (!lastRun) {
-        runs.push([item]);
-        continue;
-      }
-
-      const lastItem = lastRun[lastRun.length - 1];
-      const lastParts = parseCodeParts(lastItem.stopCode!);
-      const currParts = parseCodeParts(item.stopCode!);
-
-      if (
-        lastParts &&
-        currParts &&
-        lastParts.prefix === currParts.prefix &&
-        currParts.num === lastParts.num + 1
-      ) {
-        lastRun.push(item);
-      } else {
-        runs.push([item]);
-      }
-    }
-
-    for (const run of runs) {
-      if (run.length >= 2) {
-        const codes = run.map((r) => r.stopCode!).filter(Boolean);
-        const runStops = run.map((r) => r.stop);
-        result.push({
-          id: `group:${runStops.map((s) => s.stopId).join(",")}`,
-          baseName,
-          codes,
-          stops: runStops,
-          displayName: baseName,
-          displayCodes: `(${formatCodeRange(codes)})`,
-          displaySecondary: run[0]?.displaySecondary ?? "",
-        });
-      } else {
-        const item = run[0];
-        result.push({
-          id: `stop:${item.stop.stopId}`,
-          baseName,
-          codes: item.stopCode ? [item.stopCode] : [],
-          stops: [item.stop],
-          displayName: baseName,
-          displayCodes: item.stopCode ? `(${item.stopCode})` : "",
-          displaySecondary: item.displaySecondary,
-        });
-      }
-    }
-
-    for (const item of withoutCodes) {
-      result.push({
-        id: `stop:${item.stop.stopId}`,
-        baseName,
-        codes: [],
-        stops: [item.stop],
-        displayName: baseName,
-        displayCodes: "",
-        displaySecondary: item.displaySecondary,
-      });
-    }
-  }
-
-  return result;
 }
 
 export function StopSearch({
@@ -248,13 +80,17 @@ export function StopSearch({
       if (stop) {
         const fullName = formatStopName(stop, lang);
         const parsed = parseKmbStopName(fullName);
-        return parsed.stopCode ? `${parsed.name} (${parsed.stopCode})` : parsed.name;
+        return parsed.stopCode
+          ? `${parsed.name} (${parsed.stopCode})`
+          : parsed.name;
       }
       return null;
     }
     if (value.type === "stops") {
       // Find first stop to get base name
-      const firstStop = value.stopIds.map((stopId) => stopById.get(stopId)).find(Boolean);
+      const firstStop = value.stopIds
+        .map((stopId) => stopById.get(stopId))
+        .find(Boolean);
       if (!firstStop) return null;
 
       const fullName = formatStopName(firstStop, lang);
@@ -276,42 +112,16 @@ export function StopSearch({
       return baseName;
     }
     if (value.type === "contains") {
-      return (lang === "en" ? "Contains: " : lang === "sc" ? "包含: " : "包含: ") + value.query;
+      return (
+        (lang === "en" ? "Contains: " : lang === "sc" ? "包含: " : "包含: ") +
+        value.query
+      );
     }
     return null;
   }, [value, stopById, lang]);
 
-
   const stopComputed = React.useMemo<StopComputed[]>(() => {
-    return stops.map((stop) => {
-      const fullName = formatStopName(stop, lang);
-      const parsed = parseKmbStopName(fullName);
-      const baseName = parsed.name;
-      const stopCode = parsed.stopCode;
-      const displayName = baseName;
-      const displaySecondary = formatStopSecondary(stop, lang);
-
-      const searchName = displayName.toLowerCase().trim();
-      const searchSecondary = displaySecondary.toLowerCase().trim();
-      const searchCode = (stopCode ?? "").toLowerCase().trim();
-
-      const normalized = `${stop.nameEn}|${stop.nameTc}|${stop.nameSc}|${baseName}|${stopCode ?? ""}`
-        .toLowerCase()
-        .trim();
-
-      return {
-        stopId: stop.stopId,
-        baseName,
-        stopCode,
-        displaySecondary,
-        displayName,
-        searchName,
-        searchSecondary,
-        searchCode,
-        normalized,
-        stop,
-      };
-    });
+    return stops.map((stop) => buildStopComputed(stop, lang));
   }, [stops, lang]);
 
   const fuse = React.useMemo(() => {
@@ -325,8 +135,8 @@ export function StopSearch({
       shouldSort: true,
       keys: [
         { name: "searchCode", weight: 0.55 },
-        { name: "searchName", weight: 0.30 },
-        { name: "searchSecondary", weight: 0.10 },
+        { name: "searchName", weight: 0.3 },
+        { name: "searchSecondary", weight: 0.1 },
         { name: "normalized", weight: 0.05 },
       ],
     });
@@ -390,14 +200,17 @@ export function StopSearch({
   const trimmedQuery = query.trim();
   const canSearchContains = trimmedQuery.length >= 3;
 
-  const handleSelectGroup = React.useCallback((group: StopGroup) => {
-    if (group.stops.length === 1) {
-      onSelectStop(group.stops[0]);
-    } else {
-      onSelectStops(group.stops);
-    }
-    setOpen(false);
-  }, [onSelectStop, onSelectStops]);
+  const handleSelectGroup = React.useCallback(
+    (group: StopGroup) => {
+      if (group.stops.length === 1) {
+        onSelectStop(group.stops[0]);
+      } else {
+        onSelectStops(group.stops);
+      }
+      setOpen(false);
+    },
+    [onSelectStop, onSelectStops],
+  );
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -411,19 +224,33 @@ export function StopSearch({
           className={cn(
             "w-full min-w-0 justify-start rounded-2xl border bg-card/70 text-left shadow-sm",
             "hover:bg-card",
-            !selectedLabel && "text-muted-foreground"
+            !selectedLabel && "text-muted-foreground",
           )}
         >
           <Search className="mr-2 h-4 w-4 shrink-0" />
           <span className="truncate">
-            {selectedLabel || (lang === "en" ? "Search stop name..." : lang === "sc" ? "搜尋車站…" : "搜尋車站…")}
+            {selectedLabel ||
+              (lang === "en"
+                ? "Search stop name..."
+                : lang === "sc"
+                  ? "搜尋車站…"
+                  : "搜尋車站…")}
           </span>
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[min(560px,calc(100vw-2rem))] p-0" align="start">
+      <PopoverContent
+        className="w-[min(560px,calc(100vw-2rem))] p-0"
+        align="start"
+      >
         <Command shouldFilter={false}>
           <CommandInput
-            placeholder={lang === "en" ? "Type a stop name…" : lang === "sc" ? "輸入車站名稱…" : "輸入車站名稱…"}
+            placeholder={
+              lang === "en"
+                ? "Type a stop name…"
+                : lang === "sc"
+                  ? "輸入車站名稱…"
+                  : "輸入車站名稱…"
+            }
             aria-label={
               lang === "en"
                 ? "Search stop name"
@@ -438,8 +265,14 @@ export function StopSearch({
             id={listId}
             className={cn(isSearching && "opacity-60 transition-opacity")}
           >
-            <CommandEmpty>{lang === "en" ? "No results." : "無結果。"}</CommandEmpty>
-            <CommandGroup heading={lang === "en" ? "Stops" : lang === "sc" ? "车站" : "車站"}>
+            <CommandEmpty>
+              {lang === "en" ? "No results." : "無結果。"}
+            </CommandEmpty>
+            <CommandGroup
+              heading={
+                lang === "en" ? "Stops" : lang === "sc" ? "车站" : "車站"
+              }
+            >
               {canSearchContains ? (
                 <CommandItem
                   key={`contains:${trimmedQuery}`}
@@ -455,7 +288,11 @@ export function StopSearch({
                   </div>
                   <div className="min-w-0">
                     <div className="truncate font-medium">
-                      {(lang === "en" ? "Contains: " : lang === "sc" ? "包含：" : "包含：") + trimmedQuery}
+                      {(lang === "en"
+                        ? "Contains: "
+                        : lang === "sc"
+                          ? "包含："
+                          : "包含：") + trimmedQuery}
                     </div>
                     <div className="truncate text-xs text-muted-foreground">
                       {lang === "en"
@@ -469,13 +306,12 @@ export function StopSearch({
               ) : trimmedQuery.length ? (
                 <div className="px-2 py-1 text-xs text-muted-foreground">
                   {lang === "en"
-                    ? "Type 3+ characters for \"contains\" search."
+                    ? 'Type 3+ characters for "contains" search.'
                     : lang === "sc"
                       ? "输入 3 个以上字符以进行“包含”搜索。"
                       : "輸入 3 個以上字符以進行「包含」搜尋。"}
                 </div>
               ) : null}
-
 
               {groupedResults.map((group) => (
                 <CommandItem

--- a/lib/eta/nearby-stops.ts
+++ b/lib/eta/nearby-stops.ts
@@ -1,0 +1,91 @@
+/**
+ * Nearby stops finder using Haversine distance formula
+ */
+
+import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
+import {
+  buildStopComputed,
+  groupStopsByName,
+  type StopGroup,
+} from "@/lib/eta/stop-grouping";
+
+export type NearbyStopsOptions = {
+  maxDistanceMeters: number;
+  maxGroups: number;
+};
+
+const EARTH_RADIUS_METERS = 6371000;
+
+/**
+ * Calculate distance between two coordinates using Haversine formula.
+ * Returns distance in meters.
+ */
+export function haversineDistance(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number
+): number {
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_METERS * c;
+}
+
+function toRadians(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}
+
+/**
+ * Find nearby stops grouped by name, sorted by distance.
+ * Returns up to maxGroups groups within maxDistanceMeters.
+ */
+export function findNearbyStopGroups(
+  stops: KmbStopSearchItem[],
+  userLocation: { lat: number; lng: number },
+  lang: UiLanguage,
+  options: NearbyStopsOptions
+): StopGroup[] {
+  const { maxDistanceMeters, maxGroups } = options;
+
+  const stopsWithDistance = stops
+    .map((stop) => ({
+      stop,
+      distance: haversineDistance(
+        userLocation.lat,
+        userLocation.lng,
+        stop.lat,
+        stop.lng
+      ),
+    }))
+    .filter((item) => item.distance <= maxDistanceMeters)
+    .sort((a, b) => a.distance - b.distance);
+
+  const computed = stopsWithDistance.map((item) => buildStopComputed(item.stop, lang));
+
+  const grouped = groupStopsByName(computed);
+
+  return grouped.slice(0, maxGroups);
+}
+
+/**
+ * Find nearby stops and return flat list of stop IDs.
+ * Useful for passing directly to ETA fetcher.
+ */
+export function findNearbyStopIds(
+  stops: KmbStopSearchItem[],
+  userLocation: { lat: number; lng: number },
+  lang: UiLanguage,
+  options: NearbyStopsOptions
+): string[] {
+  const groups = findNearbyStopGroups(stops, userLocation, lang, options);
+  return groups.flatMap((g) => g.stops.map((s) => s.stopId));
+}

--- a/lib/eta/stop-grouping.ts
+++ b/lib/eta/stop-grouping.ts
@@ -1,0 +1,215 @@
+/**
+ * Shared utilities for grouping KMB stops by stop code
+ */
+
+import type { KmbStopSearchItem, UiLanguage } from "@/lib/eta/types";
+import { parseKmbStopName } from "@/lib/eta/kmb-stop-name";
+
+export type StopGroup = {
+  id: string;
+  baseName: string;
+  codes: string[];
+  stops: KmbStopSearchItem[];
+  displayName: string;
+  displayCodes: string;
+  displaySecondary: string;
+};
+
+export type StopComputed = {
+  stopId: string;
+  baseName: string;
+  stopCode: string | null;
+  displayName: string;
+  displaySecondary: string;
+  searchName: string;
+  searchSecondary: string;
+  searchCode: string;
+  normalized: string;
+  stop: KmbStopSearchItem;
+};
+
+function formatStopName(stop: KmbStopSearchItem, lang: UiLanguage): string {
+  if (lang === "sc") return stop.nameSc;
+  if (lang === "en") return stop.nameEn;
+  return stop.nameTc;
+}
+
+function formatStopSecondary(stop: KmbStopSearchItem, lang: UiLanguage): string {
+  if (lang === "en") return stop.nameTc;
+  return stop.nameEn;
+}
+
+/**
+ * Parse a stop code into prefix and numeric parts.
+ * e.g., "KT313" → { prefix: "KT", num: 313 }
+ */
+export function parseCodeParts(code: string): { prefix: string; num: number } | null {
+  const match = code.match(/^([A-Z]{1,2})(\d+)$/);
+  if (!match) return null;
+  return { prefix: match[1], num: parseInt(match[2], 10) };
+}
+
+/**
+ * Check if a set of codes are sequential (same prefix, consecutive numbers).
+ */
+export function areCodesSequential(codes: string[]): boolean {
+  if (codes.length <= 1) return true;
+  const parsed = codes.map(parseCodeParts).filter(Boolean) as { prefix: string; num: number }[];
+  if (parsed.length !== codes.length) return false;
+
+  const prefix = parsed[0].prefix;
+  if (!parsed.every((p) => p.prefix === prefix)) return false;
+
+  const nums = parsed.map((p) => p.num).sort((a, b) => a - b);
+  for (let i = 1; i < nums.length; i++) {
+    if (nums[i] !== nums[i - 1] + 1) return false;
+  }
+  return true;
+}
+
+/**
+ * Format a range of sequential codes.
+ * e.g., ["KT313", "KT314", "KT315", "KT316"] → "KT313-KT316"
+ */
+export function formatCodeRange(codes: string[]): string {
+  if (codes.length === 0) return "";
+  if (codes.length === 1) return codes[0];
+
+  const sorted = [...codes].sort((a, b) => {
+    const pa = parseCodeParts(a);
+    const pb = parseCodeParts(b);
+    if (!pa || !pb) return a.localeCompare(b);
+    return pa.num - pb.num;
+  });
+
+  return `${sorted[0]}-${sorted[sorted.length - 1]}`;
+}
+
+/**
+ * Build StopComputed for a stop - precomputes fields needed for grouping and display.
+ */
+export function buildStopComputed(stop: KmbStopSearchItem, lang: UiLanguage): StopComputed {
+  const fullName = formatStopName(stop, lang);
+  const parsed = parseKmbStopName(fullName);
+  const baseName = parsed.name;
+  const stopCode = parsed.stopCode;
+  const displayName = baseName;
+  const displaySecondary = formatStopSecondary(stop, lang);
+
+  const searchName = displayName.toLowerCase().trim();
+  const searchSecondary = displaySecondary.toLowerCase().trim();
+  const searchCode = (stopCode ?? "").toLowerCase().trim();
+
+  const normalized = `${stop.nameEn}|${stop.nameTc}|${stop.nameSc}|${baseName}|${stopCode ?? ""}`
+    .toLowerCase()
+    .trim();
+
+  return {
+    stopId: stop.stopId,
+    baseName,
+    stopCode,
+    displaySecondary,
+    displayName,
+    searchName,
+    searchSecondary,
+    searchCode,
+    normalized,
+    stop,
+  };
+}
+
+/**
+ * Group stops by their base name (without code) and merge those with sequential codes.
+ * Handles multiple separate sequential sets (e.g., KT313-KT316 AND KT681-KT683).
+ * Non-sequential stops remain as individual items.
+ */
+export function groupStopsByName(stops: StopComputed[]): StopGroup[] {
+  const byBaseName = new Map<string, StopComputed[]>();
+  for (const stop of stops) {
+    const baseName = stop.baseName;
+    if (!byBaseName.has(baseName)) {
+      byBaseName.set(baseName, []);
+    }
+    byBaseName.get(baseName)!.push(stop);
+  }
+
+  const result: StopGroup[] = [];
+
+  for (const [baseName, items] of byBaseName) {
+    const withCodes = items.filter((i) => i.stopCode !== null);
+    const withoutCodes = items.filter((i) => i.stopCode === null);
+
+    withCodes.sort((a, b) => {
+      const pa = parseCodeParts(a.stopCode!);
+      const pb = parseCodeParts(b.stopCode!);
+      if (!pa || !pb) return 0;
+      if (pa.prefix !== pb.prefix) return pa.prefix.localeCompare(pb.prefix);
+      return pa.num - pb.num;
+    });
+
+    const runs: StopComputed[][] = [];
+    for (const item of withCodes) {
+      const lastRun = runs[runs.length - 1];
+      if (!lastRun) {
+        runs.push([item]);
+        continue;
+      }
+
+      const lastItem = lastRun[lastRun.length - 1];
+      const lastParts = parseCodeParts(lastItem.stopCode!);
+      const currParts = parseCodeParts(item.stopCode!);
+
+      if (
+        lastParts &&
+        currParts &&
+        lastParts.prefix === currParts.prefix &&
+        currParts.num === lastParts.num + 1
+      ) {
+        lastRun.push(item);
+      } else {
+        runs.push([item]);
+      }
+    }
+
+    for (const run of runs) {
+      if (run.length >= 2) {
+        const codes = run.map((r) => r.stopCode!).filter(Boolean);
+        const runStops = run.map((r) => r.stop);
+        result.push({
+          id: `group:${runStops.map((s) => s.stopId).join(",")}`,
+          baseName,
+          codes,
+          stops: runStops,
+          displayName: baseName,
+          displayCodes: `(${formatCodeRange(codes)})`,
+          displaySecondary: run[0]?.displaySecondary ?? "",
+        });
+      } else {
+        const item = run[0];
+        result.push({
+          id: `stop:${item.stop.stopId}`,
+          baseName,
+          codes: item.stopCode ? [item.stopCode] : [],
+          stops: [item.stop],
+          displayName: baseName,
+          displayCodes: item.stopCode ? `(${item.stopCode})` : "",
+          displaySecondary: item.displaySecondary,
+        });
+      }
+    }
+
+    for (const item of withoutCodes) {
+      result.push({
+        id: `stop:${item.stop.stopId}`,
+        baseName,
+        codes: [],
+        stops: [item.stop],
+        displayName: baseName,
+        displayCodes: "",
+        displaySecondary: item.displaySecondary,
+      });
+    }
+  }
+
+  return result;
+}

--- a/lib/eta/use-geolocation.ts
+++ b/lib/eta/use-geolocation.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import * as React from "react";
+import { useAppStore, type CachedLocation } from "@/lib/store";
+
+const LOCATION_CACHE_MS = 5 * 60 * 1000;
+
+export type GeolocationState = {
+  location: CachedLocation | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export type UseGeolocationReturn = GeolocationState & {
+  requestLocation: () => Promise<CachedLocation | null>;
+};
+
+export function useGeolocation(): UseGeolocationReturn {
+  const lastKnownLocation = useAppStore((s) => s.lastKnownLocation);
+  const setLastKnownLocation = useAppStore((s) => s.setLastKnownLocation);
+
+  const [state, setState] = React.useState<GeolocationState>({
+    location: lastKnownLocation,
+    loading: false,
+    error: null,
+  });
+
+  const isLocationFresh = React.useCallback((loc: CachedLocation | null): boolean => {
+    if (!loc) return false;
+    return Date.now() - loc.timestamp < LOCATION_CACHE_MS;
+  }, []);
+
+  const requestLocation = React.useCallback(async (): Promise<CachedLocation | null> => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      const error = "Geolocation not supported";
+      setState((prev) => ({ ...prev, error, loading: false }));
+      return null;
+    }
+
+    if (isLocationFresh(lastKnownLocation)) {
+      setState((prev) => ({ ...prev, location: lastKnownLocation, loading: false }));
+      return lastKnownLocation;
+    }
+
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    return new Promise((resolve) => {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const loc: CachedLocation = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+            timestamp: Date.now(),
+          };
+          setLastKnownLocation(loc);
+          setState({ location: loc, loading: false, error: null });
+          resolve(loc);
+        },
+        (err) => {
+          let error: string;
+          switch (err.code) {
+            case err.PERMISSION_DENIED:
+              error = "Location permission denied";
+              break;
+            case err.POSITION_UNAVAILABLE:
+              error = "Location unavailable";
+              break;
+            case err.TIMEOUT:
+              error = "Location request timed out";
+              break;
+            default:
+              error = "Failed to get location";
+          }
+          setState((prev) => ({ ...prev, error, loading: false }));
+          resolve(null);
+        },
+        {
+          enableHighAccuracy: false,
+          timeout: 10000,
+          maximumAge: LOCATION_CACHE_MS,
+        }
+      );
+    });
+  }, [lastKnownLocation, setLastKnownLocation, isLocationFresh]);
+
+  return {
+    ...state,
+    requestLocation,
+  };
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -6,66 +6,72 @@ import { persist } from "zustand/middleware";
 
 export type RouteFilterMode = "simple" | "advanced";
 
+export type CachedLocation = {
+  lat: number;
+  lng: number;
+  timestamp: number;
+};
+
 type FavoritesMeta = {
   pinned?: boolean;
   groupId?: string | null;
 };
 
-export type FavoritesItem = FavoritesMeta & (
+export type FavoritesItem = FavoritesMeta &
   // KMB: single stop
-  | {
-      id: string;
-      mode: "kmb";
-      title: string;
-      stopId: string;
-      // Route filter - simple mode (legacy field name for backward compat)
-      route?: string;
-      serviceType?: string;
-      // Extended route filter fields
-      routeFilterMode?: RouteFilterMode;
-      entries?: { variantKey: string }[];
-    }
-  // KMB: grouped stops (multiple stops with same name)
-  | {
-      id: string;
-      mode: "kmb";
-      title: string;
-      stopIds: string[];
-      // Route filter
-      routeFilterMode?: RouteFilterMode;
-      route?: string;
-      entries?: { variantKey: string }[];
-    }
-  // KMB: contains query
-  | {
-      id: string;
-      mode: "kmb";
-      title: string;
-      query: string;
-      // Route filter - simple mode (legacy field name for backward compat)
-      route?: string;
-      serviceType?: string;
-      // Extended route filter fields
-      routeFilterMode?: RouteFilterMode;
-      entries?: { variantKey: string }[];
-    }
-  | {
-      id: string;
-      mode: "mtr";
-      // Titles are stored for display convenience only.
-      // They may be regenerated in the current UI language.
-      title: string;
-      // Keep one representative line for backward compatibility.
-      line: string;
-      sta: string;
-    }
-  | {
-      id: string;
-      mode: "lrt";
-      title: string;
-      stationId: string;
-    }
-);
+  (| {
+        id: string;
+        mode: "kmb";
+        title: string;
+        stopId: string;
+        // Route filter - simple mode (legacy field name for backward compat)
+        route?: string;
+        serviceType?: string;
+        // Extended route filter fields
+        routeFilterMode?: RouteFilterMode;
+        entries?: { variantKey: string }[];
+      }
+    // KMB: grouped stops (multiple stops with same name)
+    | {
+        id: string;
+        mode: "kmb";
+        title: string;
+        stopIds: string[];
+        // Route filter
+        routeFilterMode?: RouteFilterMode;
+        route?: string;
+        entries?: { variantKey: string }[];
+      }
+    // KMB: contains query
+    | {
+        id: string;
+        mode: "kmb";
+        title: string;
+        query: string;
+        // Route filter - simple mode (legacy field name for backward compat)
+        route?: string;
+        serviceType?: string;
+        // Extended route filter fields
+        routeFilterMode?: RouteFilterMode;
+        entries?: { variantKey: string }[];
+      }
+    | {
+        id: string;
+        mode: "mtr";
+        // Titles are stored for display convenience only.
+        // They may be regenerated in the current UI language.
+        title: string;
+        // Keep one representative line for backward compatibility.
+        line: string;
+        sta: string;
+      }
+    | {
+        id: string;
+        mode: "lrt";
+        title: string;
+        stationId: string;
+      }
+  );
 
 export type RecentItem = FavoritesItem & {
   at: number;
@@ -86,6 +92,8 @@ type AppState = {
   favoritesGroups: FavoritesGroup[];
   recents: RecentItem[];
 
+  lastKnownLocation: CachedLocation | null;
+
   setMode: (mode: TransportMode) => void;
   setLang: (lang: UiLanguage) => void;
   setRouteFilterMode: (mode: RouteFilterMode) => void;
@@ -101,6 +109,7 @@ type AppState = {
 
   addRecent: (item: FavoritesItem) => void;
   clearRecents: () => void;
+  setLastKnownLocation: (loc: CachedLocation | null) => void;
 };
 
 const RECENTS_LIMIT = 12;
@@ -129,6 +138,8 @@ export const useAppStore = create<AppState>()(
       favorites: [],
       favoritesGroups: [],
       recents: [],
+
+      lastKnownLocation: null,
 
       setMode: (mode) => set({ mode }),
       setLang: (lang) => set({ lang }),
@@ -161,7 +172,10 @@ export const useAppStore = create<AppState>()(
             favorites.unshift(updated);
           } else {
             let insertIndex = 0;
-            while (insertIndex < favorites.length && favorites[insertIndex].pinned) {
+            while (
+              insertIndex < favorites.length &&
+              favorites[insertIndex].pinned
+            ) {
               insertIndex += 1;
             }
             favorites.splice(insertIndex, 0, updated);
@@ -178,7 +192,10 @@ export const useAppStore = create<AppState>()(
 
           const targetIndex = direction === "up" ? index - 1 : index + 1;
           if (targetIndex < 0 || targetIndex >= favorites.length) return state;
-          if (Boolean(favorites[index].pinned) !== Boolean(favorites[targetIndex].pinned)) {
+          if (
+            Boolean(favorites[index].pinned) !==
+            Boolean(favorites[targetIndex].pinned)
+          ) {
             return state;
           }
 
@@ -201,7 +218,7 @@ export const useAppStore = create<AppState>()(
           if (!trimmed) return state;
           return {
             favoritesGroups: state.favoritesGroups.map((group) =>
-              group.id === id ? { ...group, name: trimmed } : group
+              group.id === id ? { ...group, name: trimmed } : group,
             ),
           };
         }),
@@ -209,9 +226,11 @@ export const useAppStore = create<AppState>()(
       deleteFavoriteGroup: (id) =>
         set((state) => ({
           favorites: state.favorites.map((favorite) =>
-            favorite.groupId === id ? { ...favorite, groupId: null } : favorite
+            favorite.groupId === id ? { ...favorite, groupId: null } : favorite,
           ),
-          favoritesGroups: state.favoritesGroups.filter((group) => group.id !== id),
+          favoritesGroups: state.favoritesGroups.filter(
+            (group) => group.id !== id,
+          ),
         })),
 
       assignFavoriteGroup: (favoriteId, groupId) =>
@@ -219,7 +238,7 @@ export const useAppStore = create<AppState>()(
           favorites: state.favorites.map((favorite) =>
             favorite.id === favoriteId
               ? { ...favorite, groupId: groupId ?? null }
-              : favorite
+              : favorite,
           ),
         })),
 
@@ -237,14 +256,16 @@ export const useAppStore = create<AppState>()(
         }),
 
       clearRecents: () => set({ recents: [] }),
+
+      setLastKnownLocation: (loc) => set({ lastKnownLocation: loc }),
     }),
     {
       name: "hk-eta",
-      version: 2,
+      version: 3,
       migrate: (persistedState) => {
         const state = persistedState as Partial<AppState> | undefined;
         const favorites = (state?.favorites ?? []).map((favorite) =>
-          withFavoriteMeta(favorite)
+          withFavoriteMeta(favorite),
         );
 
         return {
@@ -255,6 +276,7 @@ export const useAppStore = create<AppState>()(
           favorites,
           favoritesGroups: state?.favoritesGroups ?? [],
           recents: state?.recents ?? [],
+          lastKnownLocation: state?.lastKnownLocation ?? null,
         };
       },
       partialize: (state) => ({
@@ -265,7 +287,8 @@ export const useAppStore = create<AppState>()(
         favorites: state.favorites,
         favoritesGroups: state.favoritesGroups,
         recents: state.recents,
+        lastKnownLocation: state.lastKnownLocation,
       }),
-    }
-  )
+    },
+  ),
 );


### PR DESCRIPTION
## Summary

- Add `CachedLocation` type and `lastKnownLocation` state to Zustand store with v3 migration for persisted users
- Integrate `NearbyStopsButton` into KMB search pane (below search, above filter)
- Show error toasts when geolocation fails (permission denied, timeout, etc.)
- Remove unused `hasRequested` state from `NearbyStopsButton`
- Refactor `stop-search.tsx` to use shared grouping logic from `lib/eta/stop-grouping`, eliminating ~180 lines of duplicate code