### PR TITLE
perf(eta): consolidated stop-routes index for faster traversal

### DIFF
--- a/lib/eta/direct/eta-db.ts
+++ b/lib/eta/direct/eta-db.ts
@@ -13,7 +13,7 @@ import {
   buildEtaDbIndexes,
   normalizeBound,
   normalizeStopId,
-  routeStopSeqKey,
+  routeVariantKey,
   type EtaDbIndexes,
   type KmbRouteInfoLite,
   type KmbRouteStopLite,
@@ -199,48 +199,34 @@ export async function fetchKmbEtasForStop(params: {
   language: UiLanguage
 }): Promise<KmbEta[]> {
   const db = await getEtaDbCached()
-  const { stationToRouteIndex, routeStopSeqIndex } = await getEtaDbIndexes()
+  const { stopRoutesIndex, routeVariantIndex } = await getEtaDbIndexes()
   const stopId = normalizeStopId(params.stopId)
   const routeFilter = params.route ? params.route.toUpperCase() : null
   const serviceType = params.serviceType ? String(params.serviceType) : null
   const language = toHkBusEtaLanguage(params.language)
 
-  const candidates = (stationToRouteIndex.get(stopId) ?? []).filter(({ entry }) => {
-    if (routeFilter && entry.route.toUpperCase() !== routeFilter) return false
-    if (serviceType && String(entry.serviceType) !== serviceType) return false
+  const routeEntries = (stopRoutesIndex.get(stopId) ?? []).filter((e) => {
+    if (routeFilter && e.route.toUpperCase() !== routeFilter) return false
+    if (serviceType && String(e.serviceType) !== serviceType) return false
     return true
   })
 
-  if (candidates.length === 0) return [] as KmbEta[]
+  if (routeEntries.length === 0) return [] as KmbEta[]
 
   const candidateMap = new Map<string, { entry: RouteListEntry; co: Company; stopIndex: number }>()
 
-  for (const { entry, co } of candidates) {
-    const bound = normalizeBound(entry.bound[co])
-    const seqKey = routeStopSeqKey({
-      co,
-      route: entry.route,
-      bound,
-      serviceType: entry.serviceType,
-      stopId,
+  for (const re of routeEntries) {
+    const variantKey = routeVariantKey({
+      co: re.co,
+      route: re.route,
+      bound: re.bound,
+      serviceType: re.serviceType,
     })
-    let smallestIndex = routeStopSeqIndex.get(seqKey) ?? -1
-
-    if (smallestIndex < 0) {
-      const stops = entry.stops[co] ?? []
-      for (let idx = 0; idx < stops.length; idx += 1) {
-        if (normalizeStopId(stops[idx]) === stopId) {
-          smallestIndex = idx
-          break
-        }
-      }
-    }
-
-    if (smallestIndex < 0) continue
-    const key = `${co}|${entry.route.toUpperCase()}|${bound}|${entry.serviceType}`
-    const existing = candidateMap.get(key)
-    if (!existing || smallestIndex < existing.stopIndex) {
-      candidateMap.set(key, { entry, co, stopIndex: smallestIndex })
+    const entry = routeVariantIndex.get(variantKey)
+    if (!entry) continue
+    const existing = candidateMap.get(variantKey)
+    if (!existing || re.seq < existing.stopIndex) {
+      candidateMap.set(variantKey, { entry, co: re.co, stopIndex: re.seq })
     }
   }
 

--- a/lib/eta/eta-db-index.ts
+++ b/lib/eta/eta-db-index.ts
@@ -41,6 +41,26 @@ type BusRouteCandidate = {
   co: Company
 }
 
+export type StopRouteEntry = {
+  stopId: string
+  co: Company
+  route: string
+  bound: string
+  serviceType: string
+  seq: number
+}
+
+export type RouteVariantKey = {
+  co: Company
+  route: string
+  bound: string
+  serviceType: string
+}
+
+export function routeVariantKey(k: RouteVariantKey): string {
+  return `${k.co}|${k.route.toUpperCase()}|${k.bound}|${k.serviceType}`
+}
+
 export type EtaDbIndexes = {
   kmbRouteListEntries: RouteListEntry[]
   kmbStops: KmbStopSearchItem[]
@@ -50,6 +70,10 @@ export type EtaDbIndexes = {
   stationToRouteIndex: Map<string, BusRouteCandidate[]>
   /** O(1) lookup for stop sequence (0-indexed) by route variant + stopId. */
   routeStopSeqIndex: Map<string, number>
+  /** Consolidated index: stopId → route variants with pre-computed sequences. */
+  stopRoutesIndex: Map<string, StopRouteEntry[]>
+  /** Route variant key → RouteListEntry for fetching ETAs. */
+  routeVariantIndex: Map<string, RouteListEntry>
 }
 
 export type BuildEtaDbIndexesOptions = {
@@ -132,15 +156,26 @@ export function buildEtaDbIndexes(db: EtaDb, options: BuildEtaDbIndexesOptions):
 
   const stationToRouteIndex = new Map<string, BusRouteCandidate[]>()
   const stationToRouteDedup = new Map<string, Set<string>>()
+  const stopRoutesIndex = new Map<string, StopRouteEntry[]>()
+  const routeVariantIndex = new Map<string, RouteListEntry>()
   for (const entry of kmbRouteListEntries) {
     for (const co of entry.co) {
       if (!busCompanies.includes(co)) continue
       const stops = entry.stops[co] ?? []
       const bound = normalizeBound(entry.bound[co])
+      const variantKey = routeVariantKey({
+        co,
+        route: entry.route,
+        bound,
+        serviceType: entry.serviceType,
+      })
+      if (!routeVariantIndex.has(variantKey)) {
+        routeVariantIndex.set(variantKey, entry)
+      }
       for (const stopId of stops) {
         const key = normalizeStopId(stopId)
         if (!key) continue
-        const candidateKey = `${co}|${entry.route.toUpperCase()}|${bound}|${entry.serviceType}`
+        const candidateKey = variantKey
         const seen = stationToRouteDedup.get(key) ?? new Set<string>()
         if (seen.has(candidateKey)) continue
         seen.add(candidateKey)
@@ -149,6 +184,20 @@ export function buildEtaDbIndexes(db: EtaDb, options: BuildEtaDbIndexesOptions):
         list.push({ entry, co })
         stationToRouteIndex.set(key, list)
       }
+      stops.forEach((stopId, idx) => {
+        const key = normalizeStopId(stopId)
+        if (!key) return
+        const routeList = stopRoutesIndex.get(key) ?? []
+        routeList.push({
+          stopId: key,
+          co,
+          route: entry.route,
+          bound,
+          serviceType: entry.serviceType,
+          seq: idx,
+        })
+        stopRoutesIndex.set(key, routeList)
+      })
     }
   }
 
@@ -160,5 +209,7 @@ export function buildEtaDbIndexes(db: EtaDb, options: BuildEtaDbIndexesOptions):
     lrtRoutes,
     stationToRouteIndex,
     routeStopSeqIndex,
+    stopRoutesIndex,
+    routeVariantIndex,
   }
 }

--- a/lib/eta/hk-bus-eta.ts
+++ b/lib/eta/hk-bus-eta.ts
@@ -6,7 +6,7 @@ import {
   buildEtaDbIndexes,
   normalizeBound,
   normalizeStopId,
-  routeStopSeqKey,
+  routeVariantKey,
   type EtaDbIndexes,
   type KmbRouteInfoLite,
   type KmbRouteStopLite,
@@ -178,48 +178,34 @@ export async function fetchKmbEtasForStop(params: {
   language: UiLanguage
 }): Promise<KmbEta[]> {
   const db = await getEtaDbCached()
-  const { stationToRouteIndex, routeStopSeqIndex } = await getEtaDbIndexes()
+  const { stopRoutesIndex, routeVariantIndex } = await getEtaDbIndexes()
   const stopId = normalizeStopId(params.stopId)
   const routeFilter = params.route ? params.route.toUpperCase() : null
   const serviceType = params.serviceType ? String(params.serviceType) : null
   const language = toHkBusEtaLanguage(params.language)
 
-  const candidates = (stationToRouteIndex.get(stopId) ?? []).filter(({ entry }) => {
-    if (routeFilter && entry.route.toUpperCase() !== routeFilter) return false
-    if (serviceType && String(entry.serviceType) !== serviceType) return false
+  const routeEntries = (stopRoutesIndex.get(stopId) ?? []).filter((e) => {
+    if (routeFilter && e.route.toUpperCase() !== routeFilter) return false
+    if (serviceType && String(e.serviceType) !== serviceType) return false
     return true
   })
 
-  if (candidates.length === 0) return [] as KmbEta[]
+  if (routeEntries.length === 0) return [] as KmbEta[]
 
   const candidateMap = new Map<string, { entry: RouteListEntry; co: Company; stopIndex: number }>()
 
-  for (const { entry, co } of candidates) {
-    const bound = normalizeBound(entry.bound[co])
-    const seqKey = routeStopSeqKey({
-      co,
-      route: entry.route,
-      bound,
-      serviceType: entry.serviceType,
-      stopId,
+  for (const re of routeEntries) {
+    const variantKey = routeVariantKey({
+      co: re.co,
+      route: re.route,
+      bound: re.bound,
+      serviceType: re.serviceType,
     })
-    let smallestIndex = routeStopSeqIndex.get(seqKey) ?? -1
-
-    if (smallestIndex < 0) {
-      const stops = entry.stops[co] ?? []
-      for (let idx = 0; idx < stops.length; idx += 1) {
-        if (normalizeStopId(stops[idx]) === stopId) {
-          smallestIndex = idx
-          break
-        }
-      }
-    }
-
-    if (smallestIndex < 0) continue
-    const key = `${co}|${entry.route.toUpperCase()}|${bound}|${entry.serviceType}`
-    const existing = candidateMap.get(key)
-    if (!existing || smallestIndex < existing.stopIndex) {
-      candidateMap.set(key, { entry, co, stopIndex: smallestIndex })
+    const entry = routeVariantIndex.get(variantKey)
+    if (!entry) continue
+    const existing = candidateMap.get(variantKey)
+    if (!existing || re.seq < existing.stopIndex) {
+      candidateMap.set(variantKey, { entry, co: re.co, stopIndex: re.seq })
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `stopRoutesIndex` and `routeVariantIndex` for simpler stop→routes traversal
- Reduces ETA fetch from 2-3 Map lookups + key construction per route variant to direct access
- All 45 tests pass

## Changes
- `lib/eta/eta-db-index.ts`: New `StopRouteEntry` type, `routeVariantKey()` helper, `stopRoutesIndex` and `routeVariantIndex` maps
- `lib/eta/hk-bus-eta.ts`: Use new indexes in `fetchKmbEtasForStop`
- `lib/eta/direct/eta-db.ts`: Use new indexes in `fetchKmbEtasForStop`