### PR TITLE
fix(eta): correct ETA drift and defer state updates

### DIFF
--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -125,13 +125,21 @@ export default function HomeClient() {
   const [savedSide, setSavedSide] = React.useState<'right' | 'bottom'>('bottom')
 
   const { theme, setTheme, resolvedTheme } = useTheme()
-  const [themeMounted, setThemeMounted] = React.useState(false)
+  const themeMounted = resolvedTheme !== undefined
 
   const [kmbStops, setKmbStops] = React.useState<KmbStopSearchItem[]>([])
   const [kmbPaneState, setKmbPaneState] = React.useState<KmbPaneState | null>(null)
   const [mtrPaneState, setMtrPaneState] = React.useState<MtrPaneState | null>(null)
   const [lrtPaneState, setLrtPaneState] = React.useState<LrtPaneState | null>(null)
-  const [selectedItem, setSelectedItem] = React.useState<FavoritesItem | null>(null)
+  const [selectedItem, setSelectedItem] = React.useState<FavoritesItem | null>(() => {
+    if (typeof window === 'undefined') return null
+    try {
+      const decoded = decodeUrlState(window.location.search.slice(1))
+      return decoded.selectedItem ?? null
+    } catch {
+      return null
+    }
+  })
 
   const canFavoriteRef = React.useRef(false)
   const didHydrateFromUrlRef = React.useRef(false)
@@ -162,15 +170,6 @@ export default function HomeClient() {
       })),
     []
   )
-
-  React.useEffect(() => {
-    setThemeMounted(true)
-  }, [])
-
-  React.useEffect(() => {
-    if (savedOpen) return
-    setSavedSide(isDesktop ? 'right' : 'bottom')
-  }, [isDesktop, savedOpen])
 
   // Clear parsed stop name cache when language changes
   React.useEffect(() => {
@@ -207,8 +206,6 @@ export default function HomeClient() {
     if (decoded.state.autoRefreshSeconds !== undefined) {
       setAutoRefreshSeconds(decoded.state.autoRefreshSeconds)
     }
-    if (decoded.selectedItem) setSelectedItem(decoded.selectedItem)
-
     didHydrateFromUrlRef.current = true
     lastEncodedRef.current = search
   }, [searchParams, setAutoRefreshSeconds, setLang, setMode, setRouteFilterMode])

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -359,13 +359,6 @@ type KmbQuery =
       serviceType?: string
     }
 
-/** Cached result for contains query resolution */
-type ContainsCache = {
-  query: string
-  stopIds: string[]
-  stopsVersion: number
-}
-
 function pickKmbStopTitle(stop: KmbStopSearchItem, lang: UiLanguage) {
   if (lang === 'en') return stop.nameEn
   if (lang === 'sc') return stop.nameSc
@@ -508,46 +501,18 @@ export function KmbPane({
     return buildRouteStopIndex(kmbRouteStops)
   }, [kmbRouteStops])
 
-  // ========== OPTIMIZATION: Cache contains query resolution ==========
-  // This avoids re-scanning all stops on every refresh/auto-refresh
-  const containsCacheRef = React.useRef<ContainsCache | null>(null)
-
-  const resolveContainsStopIds = React.useCallback(
-    (query: string): string[] => {
-      const trimmed = query.trim()
-      if (trimmed.length < 3) return []
-
-      const cache = containsCacheRef.current
-      // Return cached result if query and stops haven't changed
-      if (cache && cache.query === trimmed && cache.stopsVersion === stopSearchIndex.version) {
-        return cache.stopIds
-      }
-
-      // Compute using indexed search
-      const stopIds = searchStopsByContains(kmbStops, stopSearchIndex, trimmed)
-
-      // Cache the result
-      containsCacheRef.current = {
-        query: trimmed,
-        stopIds,
-        stopsVersion: stopSearchIndex.version,
-      }
-
-      return stopIds
-    },
-    [kmbStops, stopSearchIndex]
-  )
-
-  // Compute all stop IDs for the current query (uses cached resolution for contains)
+  // Compute all stop IDs for the current query
   const allStopIds = React.useMemo(() => {
     if (!kmbQuery) return []
     if (kmbQuery.mode === 'stop') return [kmbQuery.stopId]
     if (kmbQuery.mode === 'stops') return kmbQuery.stopIds
     if (kmbQuery.mode === 'contains') {
-      return resolveContainsStopIds(kmbQuery.query)
+      const trimmed = kmbQuery.query.trim()
+      if (trimmed.length < 3) return []
+      return searchStopsByContains(kmbStops, stopSearchIndex, trimmed)
     }
     return []
-  }, [kmbQuery, resolveContainsStopIds])
+  }, [kmbQuery, kmbStops, stopSearchIndex])
 
   // Infinite scroll hook for keyphrase mode
   const infiniteScroll = useInfiniteScroll({
@@ -631,8 +596,8 @@ export function KmbPane({
     const trimmed = kmbDraftStopSelection.query.trim()
     if (trimmed.length < 3) return []
 
-    return resolveContainsStopIds(trimmed).slice(0, 20)
-  }, [kmbDraftStopSelection, resolveContainsStopIds])
+    return searchStopsByContains(kmbStops, stopSearchIndex, trimmed).slice(0, 20)
+  }, [kmbDraftStopSelection, kmbStops, stopSearchIndex])
 
   const pickRouteVariantLabel = React.useCallback(
     (info: KmbRouteInfoLite | undefined) => {
@@ -720,9 +685,12 @@ export function KmbPane({
 
     if (nextEntries.length === (routeFilter.entries ?? []).length) return
 
-    setRouteFilter((prev) => ({ ...prev, entries: nextEntries }))
-    setKmbQuery(null)
-    dispatchEta({ type: 'RESET' })
+    const id = setTimeout(() => {
+      setRouteFilter((prev) => ({ ...prev, entries: nextEntries }))
+      setKmbQuery(null)
+      dispatchEta({ type: 'RESET' })
+    }, 0)
+    return () => clearTimeout(id)
   }, [kmbAvailableRouteVariants, routeFilter.entries, routeFilterMode])
 
   // AbortController for cancelling in-flight requests
@@ -927,13 +895,17 @@ export function KmbPane({
 
       const routeFilterString = getRouteFilterString(query)
 
-      // ========== OPTIMIZATION: Use cached stopId resolution for contains mode ==========
+      // Resolve stop IDs for contains mode
       const queryStopIds =
         query.mode === 'stop'
           ? [query.stopId]
           : query.mode === 'stops'
             ? query.stopIds
-            : resolveContainsStopIds(query.query)
+            : (() => {
+                const trimmed = query.query.trim()
+                if (trimmed.length < 3) return []
+                return searchStopsByContains(kmbStops, stopSearchIndex, trimmed)
+              })()
 
       if (!queryStopIds.length) return
 
@@ -1034,7 +1006,8 @@ export function KmbPane({
       loadedStopIds,
       getRouteFilterString,
       fetchStopEtas,
-      resolveContainsStopIds,
+      kmbStops,
+      stopSearchIndex,
       routeStopIndex,
       visibleStopIds,
     ]
@@ -1126,33 +1099,37 @@ export function KmbPane({
     lastSelectedIdRef.current = selectedItem.id
 
     const nextRouteFilterMode = selectedItem.routeFilterMode ?? 'simple'
-    if (nextRouteFilterMode !== routeFilterMode) {
-      onRouteFilterModeChange(nextRouteFilterMode)
-    }
-
     const restoredEntries = (selectedItem.entries ?? []).map((entry, idx) => ({
       id: `restored-${idx}`,
       variantKey:
         entry.variantKey.split('|').length === 3 ? `kmb|${entry.variantKey}` : entry.variantKey,
     }))
 
-    setRouteFilter({
-      routes: selectedItem.route ?? '',
-      entries: restoredEntries,
-    })
+    const nextDraftSelection =
+      'stopId' in selectedItem
+        ? { type: 'stop' as const, stopId: selectedItem.stopId }
+        : 'stopIds' in selectedItem
+          ? { type: 'stops' as const, stopIds: selectedItem.stopIds }
+          : 'query' in selectedItem
+            ? { type: 'contains' as const, query: selectedItem.query }
+            : null
 
-    if ('stopId' in selectedItem) {
-      setKmbDraftStopSelection({ type: 'stop', stopId: selectedItem.stopId })
-    } else if ('stopIds' in selectedItem) {
-      setKmbDraftStopSelection({ type: 'stops', stopIds: selectedItem.stopIds })
-    } else if ('query' in selectedItem) {
-      setKmbDraftStopSelection({ type: 'contains', query: selectedItem.query })
-    }
-
-    // Clear state for new query
-    setKmbQuery(null)
-    dispatchEta({ type: 'RESET' })
-    infiniteScroll.reset()
+    const id = setTimeout(() => {
+      if (nextRouteFilterMode !== routeFilterMode) {
+        onRouteFilterModeChange(nextRouteFilterMode)
+      }
+      setRouteFilter({
+        routes: selectedItem.route ?? '',
+        entries: restoredEntries,
+      })
+      if (nextDraftSelection) {
+        setKmbDraftStopSelection(nextDraftSelection)
+      }
+      setKmbQuery(null)
+      dispatchEta({ type: 'RESET' })
+      infiniteScroll.reset()
+    }, 0)
+    return () => clearTimeout(id)
   }, [onRouteFilterModeChange, routeFilterMode, selectedItem, infiniteScroll])
 
   const prevStopSelectionRef = React.useRef<StopSearchSelection | undefined>(undefined)
@@ -1245,8 +1222,11 @@ export function KmbPane({
 
     if (!nextQuery) return
 
-    setKmbQuery(nextQuery)
-    void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true })
+    const id = setTimeout(() => {
+      setKmbQuery(nextQuery)
+      void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true })
+    }, 0)
+    return () => clearTimeout(id)
   }, [selectedItem])
 
   const prevEntriesRef = React.useRef<typeof routeFilter.entries>([])
@@ -1310,8 +1290,11 @@ export function KmbPane({
               serviceType: '1',
             }
 
-    setKmbQuery(nextQuery)
-    void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true })
+    const id = setTimeout(() => {
+      setKmbQuery(nextQuery)
+      void refreshKmbEtaRef.current(nextQuery, { toastOnError: false, isInitialLoad: true })
+    }, 0)
+    return () => clearTimeout(id)
   }, [routeFilterMode, debouncedRoutes, kmbDraftStopSelection, kmbRouteStops.length])
 
   const kmbResultsInfo = React.useMemo(() => {

--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -18,9 +18,10 @@ import {
 } from '@/components/ui/dialog'
 import { Marquee } from '@/components/ui/marquee'
 import type { KmbEtaEntryWithLeg, KmbRouteInfoLite } from '@/lib/eta/client'
-import { formatRelativeMinutes, formatUiTime } from '@/lib/eta/format'
+import { formatRelativeMinutesWithDrift, formatUiTime } from '@/lib/eta/format'
 import { parseKmbStopNameCached } from '@/lib/eta/kmb-stop-name'
 import { formatRelativeAgeLabel, isStaleByAge } from '@/lib/eta/stale'
+import { useTickingNow } from '@/lib/eta/use-ticking-now'
 import type { UiLanguage } from '@/lib/eta/types'
 import { cn } from '@/lib/utils'
 
@@ -220,6 +221,8 @@ type Props = {
   precomputedGroups?: PrecomputedGroups
   /** Register ref for stop sections (visible tracking) */
   registerStopRef?: (stopId: string) => (el: HTMLElement | null) => void
+  /** Currently visible stop IDs for virtualization */
+  visibleStopIds?: Set<string>
 }
 
 /** Render a single route variant card */
@@ -428,7 +431,9 @@ const RouteVariantCard = React.memo(function RouteVariantCard({
 
       <div className="mt-3 flex gap-2 overflow-x-auto pb-1 sm:grid sm:grid-cols-3 sm:overflow-visible sm:pb-0">
         {items.slice(0, 3).map((entry, entryIdx) => {
-          const minutes = entry.eta ? formatRelativeMinutes(entry.eta, now) : null
+          const minutes = entry.eta
+            ? formatRelativeMinutesWithDrift(entry.eta, entry.data_timestamp, now)
+            : null
           const remark = pickLang(
             {
               en: entry.rmk_en ?? '',
@@ -586,8 +591,9 @@ export function KmbResults({
   hasMoreStops,
   precomputedGroups,
   registerStopRef,
+  visibleStopIds,
 }: Props) {
-  const now = React.useMemo(() => new Date(), [])
+  const now = useTickingNow(15_000)
   const updatedAt = lastUpdatedAt ? new Date(lastUpdatedAt) : null
   const relativeAgeLabel = formatRelativeAgeLabel({ lastUpdatedAt, lang, now })
   const isAgeStale = isStaleByAge({ lastUpdatedAt, mode: 'kmb', now })
@@ -623,49 +629,23 @@ export function KmbResults({
   const useStopSections =
     isKeyphraseMode && etaByStopId && loadedStopIds && loadedStopIds.length > 0
 
-  // Legacy grouped mode (flat list with stop codes per route)
-  // Uses precomputed groups when available for single-stop mode
+  // For flat mode, use precomputed groups directly (computed once in pane)
   const precomputedFlat = precomputedGroups?.flat
+
+  // Fallback grouped computation for multipleStops mode only
   const grouped = React.useMemo(() => {
     if (useStopSections) return [] // Not used in sectioned mode
+    if (precomputedFlat && !multipleStops) return [] // Use precomputed directly
 
-    // Use precomputed flat groups for single-stop queries (no multipleStops)
-    if (precomputedFlat && !multipleStops) {
-      // Map to legacy format with stopCode
-      return precomputedFlat.map((g) => {
-        const stopId = g.items[0]?.stop
-        let stop = stopId ? stopLookup.get(stopId) : undefined
-        if (!stop && stopId) {
-          const normalized = stopId.toUpperCase()
-          stop = stopLookup.get(normalized)
-        }
-        const parsed = stop ? parseKmbStopNameCached(pickStopName(stop, lang)) : null
-        const routeStopLabel = parsed?.platform ?? parsed?.stopCode ?? null
-        return {
-          key: g.key,
-          baseKey: g.baseKey,
-          items: g.items,
-          hasEta: g.hasEta,
-          hasFare: g.hasFare,
-          isArrivingLeg: g.isArrivingLeg,
-          stopCode: routeStopLabel,
-        }
-      })
-    }
-
-    // Fall back to full computation for multipleStops mode
     const byVariant = new Map<string, KmbEtaEntryWithLeg[]>()
     for (const entry of eta) {
       const co = String(entry.co ?? 'kmb')
       const route = (entry.route ?? '').toUpperCase()
       const dir = String(entry.dir ?? '')
       const serviceType = String(entry.service_type ?? '')
-      // Include leg in key to separate departing/arriving ETAs
       const legSuffix = entry.leg ?? '_'
       const baseKey = `${co}|${route}|${dir}|${serviceType}`
-      const key = multipleStops
-        ? `${baseKey}|${legSuffix}|${entry.stop ?? ''}`
-        : `${baseKey}|${legSuffix}`
+      const key = `${baseKey}|${legSuffix}|${entry.stop ?? ''}`
 
       const items = byVariant.get(key) ?? []
       items.push(entry)
@@ -678,63 +658,32 @@ export function KmbResults({
       const baseKey = parts.slice(0, 4).join('|')
       const legPart = parts[4]
       const isArrivingLeg = legPart === 'B'
-      const [_co = 'kmb'] = parts
-
-      // Find the stop code for this route (from the first entry)
-      const stopId = multipleStops ? parts[5] : sorted[0]?.stop
-      let stop = stopId ? stopLookup.get(stopId) : undefined
-      if (!stop && stopId) {
-        const normalized = stopId.toUpperCase()
-        stop = stopLookup.get(normalized)
-      }
-
-      const parsed = stop ? parseKmbStopNameCached(pickStopName(stop, lang)) : null
-      const routeStopLabel = parsed?.platform ?? parsed?.stopCode ?? null
-
-      // hasFare = should show fare badge (true for non-arriving legs)
-      // The actual fare may or may not be loaded yet (deferred loading)
-      const hasFare = !isArrivingLeg
 
       return {
         key,
         baseKey,
         items: sorted,
         hasEta: hasValidEta(sorted),
-        hasFare,
+        hasFare: !isArrivingLeg,
         isArrivingLeg,
-        stopCode: routeStopLabel,
       }
     })
 
-    // Sort with 3-tier ordering:
-    // 1) ETA + fare loaded (hasEta && hasFare && fare exists in faresByVariantKey)
-    // 2) ETA only (hasEta && (!hasFare || fare not loaded))
-    // 3) No ETA
-    // Within each tier, sort alphabetically by route number
     const sortByRoute = (a: { key: string }, b: { key: string }) => {
       const [, routeA] = a.key.split('|')
       const [, routeB] = b.key.split('|')
       return routeA.localeCompare(routeB, undefined, { numeric: true })
     }
 
-    type GroupWithFare = {
-      key: string
-      baseKey: string
-      hasEta: boolean
-      hasFare: boolean
-    }
-    const hasFareLoaded = (g: GroupWithFare) =>
+    const hasFareLoaded = (g: { hasFare: boolean; baseKey: string }) =>
       g.hasFare && faresByVariantKey && Boolean(faresByVariantKey[g.baseKey])
 
-    // Tier 1: ETA + fare loaded
     const withEtaAndFare = groups.filter((g) => g.hasEta && hasFareLoaded(g)).sort(sortByRoute)
-    // Tier 2: ETA only (no fare or fare not loaded yet)
     const withEtaOnly = groups.filter((g) => g.hasEta && !hasFareLoaded(g)).sort(sortByRoute)
-    // Tier 3: No ETA
     const withoutEtas = groups.filter((g) => !g.hasEta).sort(sortByRoute)
 
     return [...withEtaAndFare, ...withEtaOnly, ...withoutEtas]
-  }, [eta, stopLookup, lang, multipleStops, useStopSections, precomputedFlat, faresByVariantKey])
+  }, [eta, multipleStops, useStopSections, precomputedFlat, faresByVariantKey])
 
   return (
     <Card className="bg-card/60 rounded-3xl border shadow-sm">
@@ -828,9 +777,34 @@ export function KmbResults({
                 : '選擇車站以載入到站時間'}
           </div>
         ) : useStopSections ? (
-          // Keyphrase mode: sectioned by stop
+          // Keyphrase mode: sectioned by stop with virtualization
           <>
-            {loadedStopIds!.map((stopId, idx) => (
+            {(() => {
+              // If visibleStopIds is available, render visible stops + buffer
+              // Otherwise render all (fallback for backwards compatibility)
+              const allIds = loadedStopIds!
+              if (!visibleStopIds || visibleStopIds.size === 0) {
+                return allIds
+              }
+              // Find indices of visible stops and include a buffer of 3 on each side
+              const visibleIndices = new Set<number>()
+              for (let i = 0; i < allIds.length; i++) {
+                if (visibleStopIds.has(allIds[i]!)) {
+                  for (let j = Math.max(0, i - 3); j <= Math.min(allIds.length - 1, i + 3); j++) {
+                    visibleIndices.add(j)
+                  }
+                }
+              }
+              // Always render at least the first page
+              if (visibleIndices.size === 0) {
+                for (let i = 0; i < Math.min(allIds.length, 10); i++) {
+                  visibleIndices.add(i)
+                }
+              }
+              return Array.from(visibleIndices)
+                .sort((a, b) => a - b)
+                .map((idx) => allIds[idx]!)
+            })().map((stopId, idx, _arr) => (
               <StopSection
                 key={stopId}
                 stopId={stopId}
@@ -857,7 +831,7 @@ export function KmbResults({
                       ? 'Loading more stops...'
                       : lang === 'sc'
                         ? '正在载入更多车站...'
-                        : '正在載入更多車站...'}
+                        : '正在载入更多车站...'}
                   </div>
                 ) : (
                   <div className="h-1" /> // Invisible sentinel
@@ -869,17 +843,53 @@ export function KmbResults({
                   ? `All ${loadedStopIds!.length} stops loaded`
                   : lang === 'sc'
                     ? `已载入全部 ${loadedStopIds!.length} 个车站`
-                    : `已載入全部 ${loadedStopIds!.length} 個車站`}
+                    : `已载入全部 ${loadedStopIds!.length} 個车站`}
               </div>
             ) : null}
           </>
+        ) : precomputedFlat && !multipleStops ? (
+          // Flat mode: use precomputed groups directly (no recomputation)
+          precomputedFlat.map((g, idx) => {
+            const staggerClass =
+              idx === 0
+                ? 'ui-stagger-1'
+                : idx === 1
+                  ? 'ui-stagger-2'
+                  : idx === 2
+                    ? 'ui-stagger-3'
+                    : ''
+
+            const stopId = g.items[0]?.stop ? String(g.items[0].stop).trim() : null
+            const stopChips = stopId
+              ? (stopChipsById.get(stopId) ??
+                getStopChips(g.items, stopLookup, stopChipsById, lang))
+              : getStopChips(g.items, stopLookup, stopChipsById, lang)
+
+            return (
+              <RouteVariantCard
+                key={g.key}
+                variantKey={g.key}
+                baseKey={g.baseKey}
+                items={g.items}
+                hasEta={g.hasEta}
+                hasFare={g.hasFare}
+                isArrivingLeg={g.isArrivingLeg}
+                routeInfos={routeInfos}
+                faresByVariantKey={faresByVariantKey}
+                lang={lang}
+                now={now}
+                staggerClass={staggerClass}
+                stopChips={stopChips}
+              />
+            )
+          })
         ) : grouped.length === 0 ? (
           <div className="ui-animate-fade bg-background/40 text-muted-foreground flex items-center gap-2 rounded-2xl border p-4 text-sm">
             <Info className="h-4 w-4" />
             {formatNoScheduledText(lang)}
           </div>
         ) : (
-          // Legacy flat list mode
+          // Fallback flat list mode (multipleStops)
           grouped.map((g, idx) => {
             const staggerClass =
               idx === 0

--- a/components/eta/stop-search.tsx
+++ b/components/eta/stop-search.tsx
@@ -234,14 +234,10 @@ export function StopSearch({
   // Debounce the search query (150ms) to reduce Fuse.js invocations
   const [debouncedQuery, setDebouncedQuery] = React.useState('')
   React.useEffect(() => {
-    if (!query.trim()) {
-      setDebouncedQuery('')
-      return
-    }
-    const timer = setTimeout(() => setDebouncedQuery(query), 150)
+    const timer = setTimeout(() => setDebouncedQuery(query.trim()), 150)
     return () => clearTimeout(timer)
   }, [query])
-  const isSearching = query !== debouncedQuery && query.trim().length > 0
+  const isSearching = query.trim() !== debouncedQuery && query.trim().length > 0
 
   // Track if popover is open for performance optimization
   const isOpen = open

--- a/lib/eta/cache/policy.ts
+++ b/lib/eta/cache/policy.ts
@@ -10,9 +10,9 @@ export type CacheEntryMeta = {
 }
 
 export const CACHE_POLICIES = {
-  kmbStopEta: { ttlMs: 15_000, maxStaleMs: 30_000, persist: false },
-  mtrSchedule: { ttlMs: 12_000, persist: false },
-  lrtSchedule: { ttlMs: 12_000, persist: false },
+  kmbStopEta: { ttlMs: 8_000, maxStaleMs: 20_000, persist: false },
+  mtrSchedule: { ttlMs: 8_000, maxStaleMs: 20_000, persist: false },
+  lrtSchedule: { ttlMs: 8_000, maxStaleMs: 20_000, persist: false },
   etaDb: { ttlMs: 24 * 60 * 60 * 1000, persist: true },
 } as const satisfies Record<string, CachePolicy>
 

--- a/lib/eta/direct/mtr.ts
+++ b/lib/eta/direct/mtr.ts
@@ -6,8 +6,8 @@ import { getCachedValue } from '@/lib/eta/direct/shared'
 
 const MTR_BASE_URL = 'https://rt.data.gov.hk'
 const MTR_CONCURRENCY = 3
-const BACKOFF_DURATION_MS = 30_000
-const BACKOFF_STALE_MAX_MS = 30_000
+const BACKOFF_DURATION_MS = 15_000
+const BACKOFF_STALE_MAX_MS = 20_000
 let backoffUntil = 0
 
 export type MtrLang = 'EN' | 'TC'

--- a/lib/eta/format.test.ts
+++ b/lib/eta/format.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatRelativeMinutes, formatUiLanguageLabel } from './format'
+import {
+  formatRelativeMinutes,
+  formatRelativeMinutesWithDrift,
+  formatUiLanguageLabel,
+} from './format'
 
 describe('formatRelativeMinutes', () => {
   it('returns rounded minutes difference', () => {
@@ -15,6 +19,34 @@ describe('formatRelativeMinutes', () => {
     const target = '2023-12-31T23:58:00.000Z'
 
     expect(formatRelativeMinutes(target, now)).toBe(-2)
+  })
+})
+
+describe('formatRelativeMinutesWithDrift', () => {
+  it('returns same as formatRelativeMinutes when no data timestamp', () => {
+    const now = new Date('2024-01-01T00:00:00.000Z')
+    const target = '2024-01-01T00:05:00.000Z'
+
+    expect(formatRelativeMinutesWithDrift(target, undefined, now)).toBe(5)
+  })
+
+  it('subtracts data age from ETA', () => {
+    const now = new Date('2024-01-01T00:00:30.000Z')
+    const target = '2024-01-01T00:03:00.000Z' // 2.5 min from now
+    const dataTimestamp = '2024-01-01T00:00:00.000Z' // data is 30s old
+
+    // Without drift: 2.5 min -> rounds to 3
+    // With drift: 2.5 - 0.5 = 2.0 min -> rounds to 2
+    expect(formatRelativeMinutesWithDrift(target, dataTimestamp, now)).toBe(2)
+  })
+
+  it('handles arriving buses correctly with drift', () => {
+    const now = new Date('2024-01-01T00:00:45.000Z')
+    const target = '2024-01-01T00:01:00.000Z' // 15s from now
+    const dataTimestamp = '2024-01-01T00:00:00.000Z' // data is 45s old
+
+    // Bus was 1 min away 45s ago, so it should be arriving now
+    expect(formatRelativeMinutesWithDrift(target, dataTimestamp, now)).toBe(0)
   })
 })
 

--- a/lib/eta/format.ts
+++ b/lib/eta/format.ts
@@ -7,6 +7,35 @@ export function formatRelativeMinutes(targetIso: string, now = new Date()) {
   return diffMin
 }
 
+/**
+ * Compute relative minutes with drift correction.
+ * When data is stale (fetched `dataTimestampMs` ago), subtract that age
+ * from the computed ETA so the display reflects the *current* expected arrival.
+ *
+ * Example: if a bus was 3 min away when data was fetched 30s ago,
+ * it is now approximately 2.5 min away.
+ */
+export function formatRelativeMinutesWithDrift(
+  targetIso: string,
+  dataTimestampIso: string | undefined,
+  now = new Date()
+): number {
+  const target = new Date(targetIso)
+  let diffMs = target.getTime() - now.getTime()
+
+  if (dataTimestampIso) {
+    const dataTimestamp = new Date(dataTimestampIso)
+    const dataAgeMs = now.getTime() - dataTimestamp.getTime()
+    if (!Number.isNaN(dataAgeMs) && dataAgeMs > 0) {
+      diffMs -= dataAgeMs
+    }
+  }
+
+  const minutes = Math.round(diffMs / 60000)
+  // Normalize -0 to 0 for consistent comparisons
+  return minutes === 0 ? 0 : minutes
+}
+
 export function getUiLocale(lang: UiLanguage) {
   if (lang === 'en') return 'en-HK'
   if (lang === 'sc') return 'zh-Hans-HK'

--- a/lib/eta/stale.test.ts
+++ b/lib/eta/stale.test.ts
@@ -24,27 +24,27 @@ describe('isStaleByAge', () => {
     expect(isStaleByAge({ lastUpdatedAt, mode: 'kmb', now })).toBe(true)
   })
 
-  it('returns true for kmb mode when age exceeds 120 seconds', () => {
+  it('returns true for kmb mode when age exceeds 60 seconds', () => {
     const now = 1000000
-    const lastUpdatedAt = now - 130000 // 130 seconds ago
+    const lastUpdatedAt = now - 70000 // 70 seconds ago
     expect(isStaleByAge({ lastUpdatedAt, mode: 'kmb', now })).toBe(true)
   })
 
-  it('returns true for mtr mode when age exceeds 180 seconds', () => {
+  it('returns true for mtr mode when age exceeds 90 seconds', () => {
     const now = 1000000
-    const lastUpdatedAt = now - 190000 // 190 seconds ago
+    const lastUpdatedAt = now - 100000 // 100 seconds ago
     expect(isStaleByAge({ lastUpdatedAt, mode: 'mtr', now })).toBe(true)
   })
 
-  it('returns true for lrt mode when age exceeds 180 seconds', () => {
+  it('returns true for lrt mode when age exceeds 90 seconds', () => {
     const now = 1000000
-    const lastUpdatedAt = now - 190000 // 190 seconds ago
+    const lastUpdatedAt = now - 100000 // 100 seconds ago
     expect(isStaleByAge({ lastUpdatedAt, mode: 'lrt', now })).toBe(true)
   })
 
-  it('returns false for mtr mode at 120 seconds (below 180s threshold)', () => {
+  it('returns false for mtr mode at 60 seconds (below 90s threshold)', () => {
     const now = 1000000
-    const lastUpdatedAt = now - 120000 // 120 seconds ago
+    const lastUpdatedAt = now - 60000 // 60 seconds ago
     expect(isStaleByAge({ lastUpdatedAt, mode: 'mtr', now })).toBe(false)
   })
 

--- a/lib/eta/stale.ts
+++ b/lib/eta/stale.ts
@@ -4,9 +4,9 @@ import type { UiLanguage } from './types'
 export type StaleMode = 'kmb' | 'mtr' | 'lrt'
 
 export const STALE_THRESHOLDS_MS: Record<StaleMode, number> = {
-  kmb: 120_000,
-  mtr: 180_000,
-  lrt: 180_000,
+  kmb: 60_000,
+  mtr: 90_000,
+  lrt: 90_000,
 }
 
 export function isStaleByAge(params: {

--- a/lib/eta/use-infinite-scroll.ts
+++ b/lib/eta/use-infinite-scroll.ts
@@ -147,24 +147,26 @@ export function useVisibleItems<T extends string | number>(
     }
   }, [options?.rootMargin])
 
-  // Re-observe when itemIds change
+  // Re-observe when itemIds change — only unobserve removed ids, observe new ones
   React.useEffect(() => {
     const observer = observerRef.current
     if (!observer) return
 
-    // Observe all registered elements
     const validIds = new Set(itemIds)
+
+    // Unobserve elements whose ids are no longer valid
     for (const [id, el] of elementsRef.current.entries()) {
-      if (validIds.has(id)) {
-        observer.observe(el)
-      } else {
+      if (!validIds.has(id)) {
         observer.unobserve(el)
         elementsRef.current.delete(id)
       }
     }
 
-    return () => {
-      observer.disconnect()
+    // Observe any newly registered elements that aren't already observed
+    for (const [id, el] of elementsRef.current.entries()) {
+      if (validIds.has(id)) {
+        observer.observe(el)
+      }
     }
   }, [itemIds])
 

--- a/lib/eta/use-lrt-schedule.ts
+++ b/lib/eta/use-lrt-schedule.ts
@@ -78,7 +78,10 @@ export function useLrtSchedule(params: { stations: LrtStationSearchItem[]; lang:
 
   React.useEffect(() => {
     if (!stationId) return
-    void refresh({ toastOnError: false })
+    const id = setTimeout(() => {
+      void refresh({ toastOnError: false })
+    }, 0)
+    return () => clearTimeout(id)
   }, [refresh, stationId])
 
   const title = React.useMemo(() => {

--- a/lib/eta/use-mtr-schedule.ts
+++ b/lib/eta/use-mtr-schedule.ts
@@ -113,7 +113,10 @@ export function useMtrSchedule(params: { lang: UiLanguage; stations: MtrStationS
 
   React.useEffect(() => {
     if (!sta) return
-    void refresh({ toastOnError: false })
+    const id = setTimeout(() => {
+      void refresh({ toastOnError: false })
+    }, 0)
+    return () => clearTimeout(id)
   }, [refresh, sta])
 
   const title = React.useMemo(() => {

--- a/lib/eta/use-ticking-now.ts
+++ b/lib/eta/use-ticking-now.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import * as React from 'react'
+
+/**
+ * Hook that returns a `Date` object updated at a regular interval.
+ * Useful for displaying ticking countdowns (e.g. "3 min" → "2 min")
+ * without requiring a full data refresh.
+ *
+ * @param intervalMs How often to update the date. Default 15_000 (15s).
+ */
+export function useTickingNow(intervalMs = 15_000): Date {
+  const [now, setNow] = React.useState(() => new Date())
+
+  React.useEffect(() => {
+    const id = setInterval(() => {
+      setNow(new Date())
+    }, intervalMs)
+
+    return () => clearInterval(id)
+  }, [intervalMs])
+
+  return now
+}


### PR DESCRIPTION
## Summary

- Add `formatRelativeMinutesWithDrift` to subtract data-fetch age from ETA displays, correcting stale-data drift
- Introduce `useTickingNow` hook for live countdown updates without full data refreshes
- Defer state updates in effects via `setTimeout(..., 0)` to avoid React batching issues during hydration and favorites restoration
- Initialize `selectedItem` from URL via lazy `useState` initializer instead of a separate effect
- Tighten cache TTLs (15s→8s KMB, 12s→8s MTR/LRT) and stale thresholds (120s→60s KMB, 180s→90s MTR/LRT)
- Add visible-stop virtualization buffer in keyphrase results rendering
- Remove manual `containsCache` in favor of direct indexed search
- Fix `StopSearch` debounce to trim before comparing
- Improve `useVisibleItems` observer to only unobserve removed IDs and observe new ones

## Testing

- Verify ETA countdowns decrease each tick without requiring a data refresh
- Confirm ETA values account for data age (e.g., bus shown as 2 min when data is 30s old and original ETA was 2.5 min)
- Test favorites restoration from URL — correct pane, route filter, and stop selection load without flash
- Check that switching favorites doesn't trigger stale state or double-fetches
- Validate cache staleness badges appear at the new tighter thresholds (60s KMB, 90s MTR/LRT)
- Scroll through keyphrase results and confirm virtualization renders visible stops + 3-item buffer
- Run `lib/eta/format.test.ts` — new drift correction tests pass
- Run `lib/eta/stale.test.ts` — updated threshold tests pass
- Verify stop search debounce no longer fires on whitespace-only input