### PR TITLE
fix: prevent duplicate in-flight requests for ETA data loading and separate arrow from label in route cards

### DIFF
--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -61,16 +61,16 @@ function formatRouteVariantLabel(
     // For arriving leg, show origin (where the bus came from) instead of destination
     if (isArrivingLeg) {
       const origin = pickLang(info.origin, lang)
-      if (origin) return `→ ${origin}`
+      if (origin) return origin
     }
     const destination = pickLang(info.destination, lang)
-    if (destination) return `→ ${destination}`
+    if (destination) return destination
   }
 
   // Fallback when route info not yet loaded
   if (isArrivingLeg && stopNameFallback) {
     // Use stop name as fallback for origin (they should be similar)
-    return `→ ${stopNameFallback}`
+    return stopNameFallback
   }
 
   if (!etaFallback) return ''
@@ -83,7 +83,7 @@ function formatRouteVariantLabel(
     },
     lang
   )
-  return dest ? `→ ${dest}` : ''
+  return dest
 }
 
 function formatArrivingText(lang: UiLanguage) {
@@ -318,7 +318,7 @@ const RouteVariantCard = React.memo(function RouteVariantCard({
       <DialogContent className="rounded-2xl">
         <DialogHeader>
           <DialogTitle className="text-base">
-            {route} {destination ? `→ ${destination}` : label}
+            {route} {destination ? `→ ${destination}` : label ? `→ ${label}` : ''}
           </DialogTitle>
           <DialogDescription className="sr-only">{i18n.routeAndStopDetails}</DialogDescription>
         </DialogHeader>
@@ -382,6 +382,7 @@ const RouteVariantCard = React.memo(function RouteVariantCard({
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <RouteBadge route={route} company={co} size="lg" />
             {operatorBadge}
+            <span className="shrink-0 text-sm font-medium">→ </span>
             <Marquee className="min-w-0 flex-1 text-sm font-medium">{label || 'Route'}</Marquee>
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -413,6 +414,7 @@ const RouteVariantCard = React.memo(function RouteVariantCard({
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <RouteBadge route={route} company={co} size="lg" />
           {operatorBadge}
+          <span className="shrink-0 text-sm font-medium">→ </span>
           <Marquee className="min-w-0 flex-1 text-sm font-medium">{label || 'Route'}</Marquee>
         </div>
         <div className="flex shrink-0 items-center gap-2">


### PR DESCRIPTION
## Summary

- **Deduplicate in-flight requests**: Added `inFlightIndexes` and `inFlightVariantStops` promise caching to `eta-db.ts` and `kmb-fares.ts` respectively, preventing concurrent duplicate fetches when the cache is stale
- **Separate arrow indicator from label**: Moved the `→` arrow out of `formatRouteVariantLabel()` and into a dedicated `<span>` in the route card UI, so scrolling marquee text doesn't include the arrow
- **Dialog title fix**: Adjusted dialog title to always prefix with `→` when no explicit destination is available
- **Virtualization edge case**: Reordered the visible-stop-index logic so the first-page fallback renders when `visibleStopIds` is empty or undefined, not just when empty
- **Error boundary logging**: Added `componentDidCatch` to log errors to the console

## Testing

- [x] Verified route cards render arrow separately from marquee text
- [x] Verified dialog title shows arrow prefix correctly
- [x] Verified duplicate ETA index requests are deduplicated (sequential calls return the same promise)
- [x] Verified duplicate fare variant stops requests are deduplicated
- [x] Verified virtualization still renders first page when no stops are visible
- [x] Ran `npm run build` — no TypeScript errors
- [ ] E2E tests — Not run