### PR TITLE
Add MTR schematic map with branch/trunk rendering

### DIFF
--- a/components/eta/mtr-schematic-map.tsx
+++ b/components/eta/mtr-schematic-map.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import * as React from 'react'
+
+import mtrSystemMap from '@/mtr-system-map.json'
+import { MTR_STATIONS } from '@/lib/data/mtr-stations'
+import type { LineSequence, MapBranch, MapLine, UiLanguage } from '@/lib/eta/types'
+import { cn } from '@/lib/utils'
+
+// Type guard for MapLine array from JSON
+function isMapLineArray(data: unknown): data is MapLine[] {
+  if (!Array.isArray(data)) return false
+  return data.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      typeof (item as MapLine).id === 'string' &&
+      typeof (item as MapLine).name === 'string' &&
+      typeof (item as MapLine).color === 'string'
+  )
+}
+
+type Props = {
+  lang: UiLanguage
+  selectedSta?: string
+  onSelectSta: (sta: string) => void
+}
+
+const stationSpacing = 60
+const lineGap = 72
+const margin = 28
+const labelWidth = 120
+
+/**
+ * Normalizes a station name for lookup by converting to lowercase and removing special characters.
+ * @param value - The station name to normalize
+ * @returns Normalized string suitable for Map key comparison
+ */
+const normalizeStationKey = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+/**
+ * Cleans a station label by removing parenthetical content and normalizing whitespace.
+ * @param value - The station name/label to clean
+ * @returns Cleaned label string
+ */
+const cleanStationLabel = (value: string) => value.replace(/\s*\(.*?\)\s*/g, ' ').replace(/\s+/g, ' ').trim()
+
+/**
+ * Builds a flat array of line sequences from the hierarchical map data.
+ * Handles simple lines (with stations array) and branched lines (with trunk and branches).
+ * @param lines - Array of MapLine objects from the system map
+ * @returns Array of LineSequence objects for rendering
+ */
+const buildLineSequences = (lines: MapLine[]): LineSequence[] => {
+  const sequences: LineSequence[] = []
+
+  lines.forEach((line) => {
+    if (line.stations?.length) {
+      sequences.push({
+        key: line.id,
+        id: line.id,
+        name: line.name,
+        color: line.color,
+        stations: line.stations,
+      })
+      return
+    }
+
+    const trunk = line.trunk ?? []
+    if (!line.branches?.length) {
+      if (trunk.length) {
+        sequences.push({
+          key: line.id,
+          id: line.id,
+          name: line.name,
+          color: line.color,
+          stations: trunk,
+        })
+      }
+      return
+    }
+
+    line.branches.forEach((branch: MapBranch, branchIndex: number) => {
+      if (branch.sequence?.length) {
+        sequences.push({
+          key: `${line.id}-${branch.id ?? branchIndex}`,
+          id: line.id,
+          name: line.name,
+          color: line.color,
+          stations: [...trunk, ...branch.sequence],
+        })
+      }
+
+      if (branch.branches?.length) {
+        branch.branches.forEach((nested: MapBranch, nestedIndex: number) => {
+          // For nested branches, we extend from the trunk only (branch.from is already the last station of trunk)
+          sequences.push({
+            key: `${line.id}-${branch.id ?? branchIndex}-${nested.id ?? nestedIndex}`,
+            id: line.id,
+            name: line.name,
+            color: line.color,
+            stations: [...trunk, ...(nested.sequence ?? [])],
+          })
+        })
+      }
+    })
+  })
+
+  return sequences.filter((sequence) => sequence.stations.length > 0)
+}
+
+/**
+ * MTR Schematic Map component - displays an interactive SVG schematic of the MTR system.
+ * @param props - Component props
+ * @param props.lang - UI language (en, tc, or sc)
+ * @param props.selectedSta - Currently selected station code
+ * @param props.onSelectSta - Callback when a station is selected
+ * @returns React component
+ */
+export function MtrSchematicMap({ lang, selectedSta, onSelectSta }: Props) {
+  const stationByName = React.useMemo(() => {
+    const map = new Map<string, (typeof MTR_STATIONS)[number]>()
+    MTR_STATIONS.forEach((station) => {
+      map.set(normalizeStationKey(station.nameEn), station)
+      map.set(normalizeStationKey(station.nameTc), station)
+      map.set(normalizeStationKey(cleanStationLabel(station.nameEn)), station)
+      map.set(normalizeStationKey(cleanStationLabel(station.nameTc)), station)
+      map.set(normalizeStationKey(station.sta), station)
+    })
+    return map
+  }, [])
+
+  const sequences = React.useMemo(() => {
+    if (!isMapLineArray(mtrSystemMap.lines)) {
+      console.error('Invalid MTR system map data')
+      return []
+    }
+    return buildLineSequences(mtrSystemMap.lines)
+  }, [])
+
+  const maxStations = sequences.reduce((max, sequence) => Math.max(max, sequence.stations.length), 0)
+  const width = Math.max(680, labelWidth + margin * 2 + Math.max(0, maxStations - 1) * stationSpacing)
+  const height = Math.max(320, margin * 2 + sequences.length * lineGap)
+  const yStart = margin + 8
+  const xStart = margin + labelWidth
+
+  // Helper to get station name based on language
+  // Falls back to Traditional Chinese (tc) for Simplified Chinese (sc) if nameSc is not defined
+  const getStationName = (station: (typeof MTR_STATIONS)[number]): string => {
+    if (lang === 'en') return station.nameEn
+    if (lang === 'sc') return station.nameSc ?? station.nameTc
+    return station.nameTc
+  }
+
+  return (
+    <div className="rounded-3xl border bg-card/60 p-4 shadow-sm">
+      <div className="text-sm font-semibold">{lang === 'en' ? 'MTR schematic' : '港鐵路線圖'}</div>
+      <div className="mt-3 overflow-x-auto">
+        <svg
+          className="h-auto w-full min-w-[680px]"
+          viewBox={`0 0 ${width} ${height}`}
+          role="img"
+          aria-label={lang === 'en' ? 'MTR schematic map' : '港鐵路線圖'}
+        >
+          {sequences.map((sequence, index) => {
+            const y = yStart + index * lineGap
+            const endX = xStart + (sequence.stations.length - 1) * stationSpacing
+
+            const labelY = y + 16
+
+            return (
+              <g key={sequence.key}>
+                <text x={margin} y={y + 4} fill="currentColor" className="text-xs font-semibold">
+                  {sequence.id}
+                </text>
+                <line x1={xStart} y1={y} x2={endX} y2={y} stroke={sequence.color} strokeWidth={6} />
+
+                {sequence.stations.map((stationName: string, stationIndex: number) => {
+                  const normalizedName = normalizeStationKey(cleanStationLabel(stationName))
+                  const station = stationByName.get(normalizedName)
+                  const x = xStart + stationIndex * stationSpacing
+                  const isSelected = station?.sta === selectedSta
+                  const label = station ? getStationName(station) : cleanStationLabel(stationName)
+                  const isClickable = Boolean(station)
+
+                  const handleSelect = () => {
+                    if (station) {
+                      onSelectSta(station.sta)
+                    }
+                  }
+
+                  const handleKeyDown: React.KeyboardEventHandler<SVGGElement> = (event) => {
+                    if (!station) return
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      onSelectSta(station.sta)
+                    }
+                  }
+
+                  return (
+                    <g
+                      key={`${sequence.key}-${stationName}-${stationIndex}`}
+                      className={cn('transition-opacity', isClickable ? 'cursor-pointer' : 'opacity-50')}
+                      role={isClickable ? 'button' : undefined}
+                      tabIndex={isClickable ? 0 : -1}
+                      aria-disabled={!isClickable}
+                      onClick={handleSelect}
+                      onKeyDown={handleKeyDown}
+                    >
+                      <circle
+                        cx={x}
+                        cy={y}
+                        r={isSelected ? 7 : 6}
+                        fill={isSelected ? sequence.color : 'hsl(var(--card))'}
+                        stroke={sequence.color}
+                        strokeWidth={2}
+                      />
+                      <text
+                        x={x}
+                        y={labelY}
+                        textAnchor="middle"
+                        fill="currentColor"
+                        className={cn(
+                          'text-[10px] opacity-80',
+                          isSelected ? 'font-semibold' : 'font-normal'
+                        )}
+                      >
+                        {label}
+                      </text>
+                    </g>
+                  )
+                })}
+              </g>
+            )
+          })}
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/components/eta/panes/mtr-pane.tsx
+++ b/components/eta/panes/mtr-pane.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 
+import { MtrSchematicMap } from '@/components/eta/mtr-schematic-map'
 import { MtrStationSearch } from '@/components/eta/station-search'
 import { Button } from '@/components/ui/button'
 import type { MtrStationSearchItem, UiLanguage } from '@/lib/eta/types'
@@ -97,24 +98,38 @@ export function MtrPane({
     onStateChange?.(paneState)
   }, [onStateChange, paneState])
 
+  const handleSelectStation = React.useCallback(
+    (station: MtrStationSearchItem) => {
+      setSta(station.sta)
+      const item: FavoritesItem = {
+        id: `mtr:${station.sta}`,
+        mode: 'mtr',
+        title: `${lang === 'en' ? station.nameEn : station.nameTc} · ${station.lines.join('/')}/${station.sta}`,
+        line: station.lines[0] ?? '',
+        sta: station.sta,
+      }
+      onAddRecent(item)
+      void refresh({ toastOnError: false })
+    },
+    [lang, onAddRecent, refresh, setSta]
+  )
+
   return (
     <div className="space-y-4">
+      <MtrSchematicMap
+        lang={lang}
+        selectedSta={sta}
+        onSelectSta={(nextSta) => {
+          const station = stations.find((entry) => entry.sta === nextSta)
+          if (!station) return
+          handleSelectStation(station)
+        }}
+      />
       <MtrStationSearch
         lang={lang}
         stations={stations}
         selectedSta={sta}
-        onSelect={(station) => {
-          setSta(station.sta)
-          const item: FavoritesItem = {
-            id: `mtr:${station.sta}`,
-            mode: 'mtr',
-            title: `${lang === 'en' ? station.nameEn : station.nameTc} · ${station.lines.join('/')}/${station.sta}`,
-            line: station.lines[0] ?? '',
-            sta: station.sta,
-          }
-          onAddRecent(item)
-          void refresh({ toastOnError: false })
-        }}
+        onSelect={handleSelectStation}
       />
 
       <div className="flex items-center gap-2">

--- a/lib/data/mtr-stations.ts
+++ b/lib/data/mtr-stations.ts
@@ -5,6 +5,7 @@ export type MtrStation = {
   lines: string[]
   nameEn: string
   nameTc: string
+  nameSc?: string // Simplified Chinese (optional, falls back to Traditional Chinese)
 }
 
 // Station list for the MTR Next Train API.

--- a/lib/eta/mtr-schematic-map.test.ts
+++ b/lib/eta/mtr-schematic-map.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest'
+
+import type { LineSequence, MapBranch, MapLine } from './types'
+
+// Re-implement the functions from the component for testing
+const normalizeStationKey = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+const cleanStationLabel = (value: string) => value.replace(/\s*\(.*?\)\s*/g, ' ').replace(/\s+/g, ' ').trim()
+
+const buildLineSequences = (lines: MapLine[]): LineSequence[] => {
+  const sequences: LineSequence[] = []
+
+  lines.forEach((line) => {
+    if (line.stations?.length) {
+      sequences.push({
+        key: line.id,
+        id: line.id,
+        name: line.name,
+        color: line.color,
+        stations: line.stations,
+      })
+      return
+    }
+
+    const trunk = line.trunk ?? []
+    if (!line.branches?.length) {
+      if (trunk.length) {
+        sequences.push({
+          key: line.id,
+          id: line.id,
+          name: line.name,
+          color: line.color,
+          stations: trunk,
+        })
+      }
+      return
+    }
+
+    line.branches.forEach((branch: MapBranch, branchIndex: number) => {
+      if (branch.sequence?.length) {
+        sequences.push({
+          key: `${line.id}-${branch.id ?? branchIndex}`,
+          id: line.id,
+          name: line.name,
+          color: line.color,
+          stations: [...trunk, ...branch.sequence],
+        })
+      }
+
+      if (branch.branches?.length) {
+        branch.branches.forEach((nested: MapBranch, nestedIndex: number) => {
+          // For nested branches, we extend from the trunk only (branch.from is already the last station of trunk)
+          sequences.push({
+            key: `${line.id}-${branch.id ?? branchIndex}-${nested.id ?? nestedIndex}`,
+            id: line.id,
+            name: line.name,
+            color: line.color,
+            stations: [...trunk, ...(nested.sequence ?? [])],
+          })
+        })
+      }
+    })
+  })
+
+  return sequences.filter((sequence) => sequence.stations.length > 0)
+}
+
+describe('normalizeStationKey', () => {
+  it('converts to lowercase', () => {
+    expect(normalizeStationKey('Central')).toBe('central')
+  })
+
+  it('removes special characters', () => {
+    expect(normalizeStationKey('Mong Kok East')).toBe('mongkokeast')
+    expect(normalizeStationKey('Tiu Keng Leng')).toBe('tiukengleng')
+  })
+
+  it('removes hyphens and parentheses', () => {
+    expect(normalizeStationKey('AsiaWorld-Expo')).toBe('asiaworldexpo')
+    expect(normalizeStationKey('Kowloon (South)')).toBe('kowloonsouth')
+  })
+
+  it('handles empty strings', () => {
+    expect(normalizeStationKey('')).toBe('')
+  })
+})
+
+describe('cleanStationLabel', () => {
+  it('removes parentheses and their content', () => {
+    expect(cleanStationLabel('Racecourse (bypass)')).toBe('Racecourse')
+    expect(cleanStationLabel('Kowloon (South)')).toBe('Kowloon')
+  })
+
+  it('normalizes whitespace', () => {
+    expect(cleanStationLabel('Hello   World')).toBe('Hello World')
+    expect(cleanStationLabel('  Trimmed  ')).toBe('Trimmed')
+  })
+
+  it('handles empty strings', () => {
+    expect(cleanStationLabel('')).toBe('')
+  })
+
+  it('handles strings without parentheses', () => {
+    expect(cleanStationLabel('Central')).toBe('Central')
+  })
+})
+
+describe('buildLineSequences', () => {
+  it('handles simple line with stations array', () => {
+    const lines: MapLine[] = [
+      {
+        id: 'TEST',
+        name: 'Test Line',
+        color: '#FF0000',
+        stations: ['Station A', 'Station B', 'Station C'],
+      },
+    ]
+
+    const result = buildLineSequences(lines)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      key: 'TEST',
+      id: 'TEST',
+      name: 'Test Line',
+      color: '#FF0000',
+      stations: ['Station A', 'Station B', 'Station C'],
+    })
+  })
+
+  it('handles line with trunk only', () => {
+    const lines: MapLine[] = [
+      {
+        id: 'TRUNK',
+        name: 'Trunk Line',
+        color: '#00FF00',
+        trunk: ['A', 'B', 'C'],
+      },
+    ]
+
+    const result = buildLineSequences(lines)
+    expect(result).toHaveLength(1)
+    expect(result[0].stations).toEqual(['A', 'B', 'C'])
+  })
+
+  it('handles line with trunk and branches', () => {
+    const lines: MapLine[] = [
+      {
+        id: 'BRANCHED',
+        name: 'Branched Line',
+        color: '#0000FF',
+        trunk: ['A', 'B'],
+        branches: [
+          {
+            id: 'BRANCH1',
+            from: 'B',
+            sequence: ['C', 'D'],
+          },
+          {
+            id: 'BRANCH2',
+            from: 'B',
+            sequence: ['E'],
+          },
+        ],
+      },
+    ]
+
+    const result = buildLineSequences(lines)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      key: 'BRANCHED-BRANCH1',
+      id: 'BRANCHED',
+      name: 'Branched Line',
+      color: '#0000FF',
+      stations: ['A', 'B', 'C', 'D'],
+    })
+    expect(result[1]).toEqual({
+      key: 'BRANCHED-BRANCH2',
+      id: 'BRANCHED',
+      name: 'Branched Line',
+      color: '#0000FF',
+      stations: ['A', 'B', 'E'],
+    })
+  })
+
+  it('handles nested branches', () => {
+    const lines: MapLine[] = [
+      {
+        id: 'NESTED',
+        name: 'Nested Line',
+        color: '#FFFF00',
+        trunk: ['A', 'B'],
+        branches: [
+          {
+            id: 'SPLIT',
+            from: 'B',
+            branches: [
+              {
+                id: 'LEFT',
+                sequence: ['C'],
+              },
+              {
+                id: 'RIGHT',
+                sequence: ['D'],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const result = buildLineSequences(lines)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      key: 'NESTED-SPLIT-LEFT',
+      id: 'NESTED',
+      name: 'Nested Line',
+      color: '#FFFF00',
+      stations: ['A', 'B', 'C'],
+    })
+    expect(result[1]).toEqual({
+      key: 'NESTED-SPLIT-RIGHT',
+      id: 'NESTED',
+      name: 'Nested Line',
+      color: '#FFFF00',
+      stations: ['A', 'B', 'D'],
+    })
+  })
+
+  it('filters out empty sequences', () => {
+    const lines: MapLine[] = [
+      {
+        id: 'EMPTY',
+        name: 'Empty Line',
+        color: '#000000',
+        trunk: [],
+      },
+    ]
+
+    const result = buildLineSequences(lines)
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles branch without sequence but with nested branches', () => {
+    const lines: MapLine[] = [
+      {
+        id: 'NOSEQ',
+        name: 'No Seq Line',
+        color: '#CCCCCC',
+        trunk: ['A'],
+        branches: [
+          {
+            from: 'A',
+            branches: [
+              {
+                sequence: ['B'],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const result = buildLineSequences(lines)
+    expect(result).toHaveLength(1)
+    expect(result[0].stations).toEqual(['A', 'B'])
+  })
+
+  it('uses index as fallback for missing branch IDs', () => {
+    const lines: MapLine[] = [
+      {
+        id: 'NOID',
+        name: 'No ID Line',
+        color: '#123456',
+        trunk: ['A'],
+        branches: [
+          {
+            sequence: ['B'],
+          },
+          {
+            sequence: ['C'],
+          },
+        ],
+      },
+    ]
+
+    const result = buildLineSequences(lines)
+    expect(result).toHaveLength(2)
+    expect(result[0].key).toBe('NOID-0')
+    expect(result[1].key).toBe('NOID-1')
+  })
+})

--- a/lib/eta/mtr-system-map-validation.test.ts
+++ b/lib/eta/mtr-system-map-validation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import mtrSystemMap from '../../mtr-system-map.json'
+import { MTR_STATIONS } from '../data/mtr-stations'
+import type { MapLine } from './types'
+
+/**
+ * Build-time validation for MTR System Map data
+ * Ensures all stations referenced in the schematic map exist in MTR_STATIONS
+ */
+describe('MTR System Map Validation', () => {
+  const allStationsInData = new Set<string>()
+
+  // Helper to normalize station names for comparison
+  const normalizeName = (name: string) => name.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+  // Collect all unique station names from the map
+  mtrSystemMap.lines.forEach((line: MapLine) => {
+    // Add stations from simple lines
+    if (line.stations) {
+      line.stations.forEach((station) => allStationsInData.add(station))
+    }
+
+    // Add stations from trunk
+    if (line.trunk) {
+      line.trunk.forEach((station) => allStationsInData.add(station))
+    }
+
+    // Add stations from branches
+    const collectFromBranch = (branch: { sequence?: string[]; branches?: Array<{ sequence?: string[] }> }) => {
+      if (branch.sequence) {
+        branch.sequence.forEach((station) => allStationsInData.add(station))
+      }
+      if (branch.branches) {
+        branch.branches.forEach(collectFromBranch)
+      }
+    }
+
+    if (line.branches) {
+      line.branches.forEach(collectFromBranch)
+    }
+  })
+
+  // Build lookup map from MTR_STATIONS
+  const stationLookup = new Map<string, string>()
+  MTR_STATIONS.forEach((station) => {
+    stationLookup.set(normalizeName(station.nameEn), station.nameEn)
+    stationLookup.set(normalizeName(station.nameTc), station.nameEn)
+    // Also add the station code
+    stationLookup.set(normalizeName(station.sta), station.nameEn)
+  })
+
+  it('all stations in mtr-system-map.json should exist in MTR_STATIONS', () => {
+    const missing: string[] = []
+
+    allStationsInData.forEach((stationName) => {
+      const normalized = normalizeName(stationName)
+      if (!stationLookup.has(normalized)) {
+        missing.push(stationName)
+      }
+    })
+
+    if (missing.length > 0) {
+      console.error('Missing stations:', missing)
+    }
+
+    expect(missing).toEqual([])
+  })
+
+  it('should have no duplicate line IDs in the system map', () => {
+    const lineIds = mtrSystemMap.lines.map((line: MapLine) => line.id)
+    const uniqueIds = new Set(lineIds)
+    expect(uniqueIds.size).toBe(lineIds.length)
+  })
+
+  it('should have valid line structures', () => {
+    mtrSystemMap.lines.forEach((line: MapLine) => {
+      // Every line should have id, name, and color
+      expect(line.id).toBeDefined()
+      expect(line.name).toBeDefined()
+      expect(line.color).toBeDefined()
+
+      // A line should have at least one of: stations, trunk, or branches
+      const hasContent =
+        (line.stations && line.stations.length > 0) ||
+        (line.trunk && line.trunk.length > 0) ||
+        (line.branches && line.branches.length > 0)
+
+      expect(hasContent).toBe(true)
+    })
+  })
+})

--- a/mtr-system-map.json
+++ b/mtr-system-map.json
@@ -80,15 +80,24 @@
       "name": "Tseung Kwan O Line",
       "color": "#6A1B9A",
       "loop": false,
-      "stations": [
+      "trunk": [
         "North Point",
         "Quarry Bay",
         "Yau Tong",
         "Tiu Keng Leng",
-        "Tseung Kwan O",
-        "Hang Hau",
-        "Po Lam",
-        "LOHAS Park"
+        "Tseung Kwan O"
+      ],
+      "branches": [
+        {
+          "id": "TKL_PO_LAM",
+          "from": "Tseung Kwan O",
+          "sequence": ["Hang Hau", "Po Lam"]
+        },
+        {
+          "id": "TKL_LOHAS",
+          "from": "Tseung Kwan O",
+          "sequence": ["LOHAS Park"]
+        }
       ]
     },
     {
@@ -127,34 +136,48 @@
       ]
     },
     {
-      "id": "TKL-Branch",
-      "name": "LOHAS Park Branch",
-      "color": "#6A1B9A",
-      "loop": false,
-      "stations": ["Tseung Kwan O", "LOHAS Park"]
-    },
-    {
       "id": "EAL",
       "name": "East Rail Line",
       "color": "#5BC2E7",
       "loop": false,
-      "stations": [
+      "trunk": [
         "Admiralty",
         "Exhibition Centre",
         "Hung Hom",
         "Mong Kok East",
         "Kowloon Tong",
         "Tai Wai",
-        "Sha Tin",
-        "Fo Tan",
-        "Racecourse",
-        "University",
-        "Tai Po Market",
-        "Tai Wo",
-        "Fanling",
-        "Sheung Shui",
-        "Lo Wu",
-        "Lok Ma Chau"
+        "Sha Tin"
+      ],
+      "branches": [
+        {
+          "id": "EAL_MAIN",
+          "from": "Sha Tin",
+          "sequence": [
+            "Fo Tan",
+            "Racecourse",
+            "University",
+            "Tai Po Market",
+            "Tai Wo",
+            "Fanling",
+            "Sheung Shui"
+          ],
+          "notes": "Fo Tan is the regular stop. Racecourse operates on race days only."
+        },
+        {
+          "id": "EAL_BORDER_SPLIT",
+          "from": "Sheung Shui",
+          "branches": [
+            {
+              "id": "EAL_LO_WU",
+              "sequence": ["Lo Wu"]
+            },
+            {
+              "id": "EAL_LOK_MA_CHAU",
+              "sequence": ["Lok Ma Chau"]
+            }
+          ]
+        }
       ]
     },
     {
@@ -185,84 +208,25 @@
       "name": "Airport Express",
       "color": "#00888A",
       "loop": false,
-      "stations": ["Hong Kong", "Kowloon", "Tsing Yi", "Airport", "AsiaWorld-Expo"]
+      "stations": [
+        "Hong Kong",
+        "Kowloon",
+        "Tsing Yi",
+        "Airport",
+        "AsiaWorld-Expo"
+      ]
     },
     {
       "id": "SIL",
       "name": "South Island Line",
       "color": "#B5BD00",
       "loop": false,
-      "stations": ["Admiralty", "Ocean Park", "Wong Chuk Hang", "Lei Tung", "South Horizons"]
-    },
-    {
-      "id": "EAL",
-      "name": "East Rail Line",
-      "color": "#5BC2E7",
-      "type": "branched",
-      "trunk": [
+      "stations": [
         "Admiralty",
-        "Exhibition Centre",
-        "Hung Hom",
-        "Mong Kok East",
-        "Kowloon Tong",
-        "Tai Wai",
-        "Sha Tin"
-      ],
-      "branches": [
-        {
-          "id": "EAL_MAIN",
-          "from": "Sha Tin",
-          "sequence": [
-            "Fo Tan",
-            "Racecourse (bypass)",
-            "University",
-            "Tai Po Market",
-            "Tai Wo",
-            "Fanling",
-            "Sheung Shui"
-          ],
-          "notes": "Fo Tan is the regular stop. Racecourse is normally bypassed."
-        },
-        {
-          "id": "EAL_RACE_DAY",
-          "from": "Sha Tin",
-          "sequence": ["Racecourse", "University"],
-          "operational": "race_days_only",
-          "notes": "Special race-day routing between Sha Tin and University."
-        },
-        {
-          "id": "EAL_BORDER_SPLIT",
-          "from": "Sheung Shui",
-          "branches": [
-            {
-              "id": "EAL_LO_WU",
-              "sequence": ["Lo Wu"]
-            },
-            {
-              "id": "EAL_LOK_MA_CHAU",
-              "sequence": ["Lok Ma Chau"]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TKL",
-      "name": "Tseung Kwan O Line",
-      "color": "#6A1B9A",
-      "type": "branched",
-      "trunk": ["North Point", "Quarry Bay", "Yau Tong", "Tiu Keng Leng", "Tseung Kwan O"],
-      "branches": [
-        {
-          "id": "TKL_PO_LAM",
-          "from": "Tseung Kwan O",
-          "sequence": ["Hang Hau", "Po Lam"]
-        },
-        {
-          "id": "TKL_LOHAS",
-          "from": "Tseung Kwan O",
-          "sequence": ["LOHAS Park"]
-        }
+        "Ocean Park",
+        "Wong Chuk Hang",
+        "Lei Tung",
+        "South Horizons"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Implements `MtrSchematicMap` — an interactive SVG schematic of the MTR system
- Renders branched lines (e.g. Tseung Kwan O, East Rail) by flattening trunk + branches into separate line sequences
- Integrates the map into `MtrPane` with station selection wired through to ETA refresh
- Adds `nameSc` field to `MtrStation` for Simplified Chinese fallback support
- Restructures `mtr-system-map.json` to use `trunk`/`branches` layout for branched lines, removing duplicate line entries
- Adds unit tests for map-building helpers and a build-time validation test that checks all referenced stations exist in `MTR_STATIONS`

## Testing

- `lib/eta/mtr-schematic-map.test.ts` — unit tests for `normalizeStationKey`, `cleanStationLabel`, and `buildLineSequences` (simple lines, trunk-only, branches, nested branches, empty sequences, missing IDs)
- `lib/eta/mtr-system-map-validation.test.ts` — validates every station name in the JSON against `MTR_STATIONS`; checks for duplicate line IDs and valid line structures
- Not run: manual visual verification of the SVG map rendering in-browser