### PR TITLE
refactor: extract kmb-pane reducer and hooks (closes #62)

### DIFF
--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -33,189 +33,17 @@ import { useMediaQuery } from '@/lib/hooks/use-media-query'
 import { cn } from '@/lib/utils'
 import type { FavoritesItem, RouteFilterMode } from '@/lib/store'
 import { precomputeRenderGroups, type PrecomputedGroups } from '@/lib/eta/kmb-eta-groups'
-
-// ============================================================================
-// ETA State Reducer - Batch updates to minimize renders
-// ============================================================================
-
-type EtaState = {
-  byStopId: Record<string, KmbEtaEntryWithLeg[]>
-  loadedStopIds: string[]
-  faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
-  loading: boolean
-  error: string | null
-  stale: boolean
-  staleByStopId: Record<string, { stale: boolean; ageMs: number | null }>
-  lastUpdatedAt: number | null
-}
-
-type EtaAction =
-  | { type: 'REFRESH_START' }
-  | {
-      type: 'REFRESH_SUCCESS'
-      payload: {
-        byStopId: Record<string, KmbEtaEntryWithLeg[]>
-        loadedStopIds: string[]
-        faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
-        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>
-      }
-    }
-  | { type: 'REFRESH_ERROR'; error: string }
-  | {
-      type: 'APPEND_STOPS'
-      payload: {
-        byStopId: Record<string, KmbEtaEntryWithLeg[]>
-        newStopIds: string[]
-        faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
-        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>
-      }
-    }
-  | {
-      type: 'FARES_SUCCESS'
-      payload: {
-        faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
-      }
-    }
-  | { type: 'RESET' }
-
-const initialEtaState: EtaState = {
-  byStopId: {},
-  loadedStopIds: [],
-  faresByVariantKey: {},
-  loading: false,
-  error: null,
-  stale: false,
-  staleByStopId: {},
-  lastUpdatedAt: null,
-}
-
-function etaReducer(state: EtaState, action: EtaAction): EtaState {
-  switch (action.type) {
-    case 'REFRESH_START':
-      return { ...state, loading: true, error: null }
-    case 'REFRESH_SUCCESS':
-      return {
-        ...state,
-        byStopId: action.payload.byStopId,
-        loadedStopIds: action.payload.loadedStopIds,
-        // Keep existing fares if payload doesn't include new ones (deferred loading)
-        faresByVariantKey: action.payload.faresByVariantKey ?? state.faresByVariantKey,
-        loading: false,
-        error: null,
-        stale: Boolean(
-          action.payload.staleByStopId &&
-          Object.values(action.payload.staleByStopId).some((entry) => entry.stale)
-        ),
-        staleByStopId: action.payload.staleByStopId ?? {},
-        lastUpdatedAt: Date.now(),
-      }
-    case 'REFRESH_ERROR':
-      return {
-        ...state,
-        loading: false,
-        error: action.error,
-        stale: true,
-        staleByStopId: {},
-      }
-    case 'APPEND_STOPS':
-      return {
-        ...state,
-        byStopId: { ...state.byStopId, ...action.payload.byStopId },
-        loadedStopIds: [...state.loadedStopIds, ...action.payload.newStopIds],
-        faresByVariantKey: {
-          ...state.faresByVariantKey,
-          ...(action.payload.faresByVariantKey ?? {}),
-        },
-        loading: false,
-        staleByStopId: { ...state.staleByStopId, ...(action.payload.staleByStopId ?? {}) },
-      }
-    case 'FARES_SUCCESS':
-      return {
-        ...state,
-        faresByVariantKey: { ...state.faresByVariantKey, ...action.payload.faresByVariantKey },
-      }
-    case 'RESET':
-      return initialEtaState
-    default:
-      return state
-  }
-}
-
-// ============================================================================
-// Stop Search Index - Precompute for O(1) contains lookups
-// ============================================================================
-
-type StopSearchIndex = {
-  /** Lowercased concatenation of all name fields for each stop */
-  normalizedNames: Map<string, string>
-  /** Version counter to detect when stops change */
-  version: number
-}
-
-function buildStopSearchIndex(stops: KmbStopSearchItem[]): StopSearchIndex {
-  const normalizedNames = new Map<string, string>()
-  for (const stop of stops) {
-    const normalized = `${stop.nameEn.toLowerCase()}|${stop.nameTc.toLowerCase()}|${stop.nameSc.toLowerCase()}`
-    normalizedNames.set(stop.stopId, normalized)
-  }
-  return { normalizedNames, version: stops.length }
-}
-
-function searchStopsByContains(
-  stops: KmbStopSearchItem[],
-  index: StopSearchIndex,
-  query: string
-): string[] {
-  const needle = query.trim().toLowerCase()
-  if (!needle) return []
-
-  const result: string[] = []
-  for (const stop of stops) {
-    const normalized = index.normalizedNames.get(stop.stopId)
-    if (normalized && normalized.includes(needle)) {
-      result.push(stop.stopId)
-    }
-  }
-  return result
-}
-
-// ============================================================================
-// Route-Stop Index - O(1) lookup of variant keys by stop ID
-// ============================================================================
-
-type RouteStopIndex = {
-  /** stopId -> Set of variant keys (co|route|bound|serviceType) */
-  byStopId: Map<string, Set<string>>
-  /** Version counter */
-  version: number
-}
-
-function buildRouteStopIndex(routeStops: KmbRouteStopLite[]): RouteStopIndex {
-  const byStopId = new Map<string, Set<string>>()
-  for (const entry of routeStops) {
-    const key = `${entry.co}|${entry.route.toUpperCase()}|${entry.bound}|${entry.serviceType}`
-    let set = byStopId.get(entry.stopId)
-    if (!set) {
-      set = new Set()
-      byStopId.set(entry.stopId, set)
-    }
-    set.add(key)
-  }
-  return { byStopId, version: routeStops.length }
-}
-
-function getVariantKeysForStops(index: RouteStopIndex, stopIds: string[]): string[] {
-  const result = new Set<string>()
-  for (const stopId of stopIds) {
-    const keys = index.byStopId.get(stopId)
-    if (keys) {
-      for (const key of keys) {
-        result.add(key)
-      }
-    }
-  }
-  return Array.from(result)
-}
+import { initialEtaState, etaReducer } from '@/components/eta/panes/kmb-reducer'
+import {
+  buildRouteFilterString,
+  getVariantKeysForStops,
+} from '@/components/eta/panes/use-kmb-route-filter'
+import {
+  buildStopSearchIndex,
+  searchStopsByContains,
+  type StopSearchIndex,
+} from '@/components/eta/panes/kmb-stop-search'
+import { useKmbSave } from '@/components/eta/panes/use-kmb-save'
 
 // ============================================================================
 // Types and Helpers
@@ -260,20 +88,27 @@ function pickKmbStopTitle(stop: KmbStopSearchItem, lang: UiLanguage) {
   return stop.nameTc
 }
 
-function normalizeKmbRoutesInput(input: string) {
-  const requestedRoutes = input
-    ? input
-        .split(',')
-        .map((r) => r.trim())
-        .filter(Boolean)
-        .map((r) => r.toUpperCase())
-    : null
-
-  return requestedRoutes?.length ? requestedRoutes : null
-}
-
 /** Stops per page for infinite scroll */
 const STOPS_PER_PAGE = 10
+
+type RouteStopIndex = {
+  byStopId: Map<string, Set<string>>
+  version: number
+}
+
+function buildRouteStopIndex(routeStops: KmbRouteStopLite[]): RouteStopIndex {
+  const byStopId = new Map<string, Set<string>>()
+  for (const entry of routeStops) {
+    const key = `${entry.co}|${entry.route.toUpperCase()}|${entry.bound}|${entry.serviceType}`
+    let set = byStopId.get(entry.stopId)
+    if (!set) {
+      set = new Set()
+      byStopId.set(entry.stopId, set)
+    }
+    set.add(key)
+  }
+  return { byStopId, version: routeStops.length }
+}
 
 export type KmbPaneState = {
   lang: UiLanguage
@@ -594,23 +429,11 @@ export function KmbPane({
   // Coordination ref to prevent overlapping refresh triggers from multiple effects
   const pendingRefreshTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Build route filter string based on current filter state
   const getRouteFilterString = React.useCallback(
     (query: KmbQuery) => {
-      const advancedEntries = routeFilterMode === 'advanced' ? (routeFilter.entries ?? []) : []
-      const requestedRoutes = normalizeKmbRoutesInput(query.route?.trim() ?? '')
-
-      if (advancedEntries.length) {
-        const routesFromAdvanced = new Set(
-          advancedEntries.map((e) => e.variantKey.split('|')[1]).filter(Boolean)
-        )
-        return Array.from(routesFromAdvanced).join(',')
-      } else if (requestedRoutes) {
-        return requestedRoutes.join(',')
-      }
-      return undefined
+      return buildRouteFilterString(routeFilter, routeFilterMode, query.route)
     },
-    [routeFilter.entries, routeFilterMode]
+    [routeFilter, routeFilterMode]
   )
 
   // Fetch ETAs for a specific set of stop IDs and merge into state
@@ -1238,103 +1061,17 @@ export function KmbPane({
     canFavoriteRef.current = Boolean(canFavorite)
   }, [canFavorite, canFavoriteRef])
 
-  const onSave = () => {
-    if (!canFavorite) return
-
-    const isAdvanced = routeFilterMode === 'advanced'
-    const routeInput = isAdvanced ? '' : (routeFilter.routes?.trim() ?? '')
-    const route = routeInput || undefined
-
-    const entriesForSave =
-      isAdvanced && routeFilter.entries?.length
-        ? routeFilter.entries.map((e) => ({ variantKey: e.variantKey }))
-        : undefined
-
-    const routeCount = isAdvanced ? (routeFilter.entries?.length ?? 0) : 0
-    const routeSuffix =
-      isAdvanced && routeCount > 0
-        ? ` · ${routeCount} ${lang === 'en' ? (routeCount === 1 ? 'route' : 'routes') : '條路線'}`
-        : route
-          ? ` · ${route}`
-          : ''
-
-    const stopId =
-      kmbQuery?.mode === 'stop'
-        ? kmbQuery.stopId
-        : kmbDraftStopSelection?.type === 'stop'
-          ? kmbDraftStopSelection.stopId
-          : null
-
-    const stopIds =
-      kmbQuery?.mode === 'stops'
-        ? kmbQuery.stopIds
-        : kmbDraftStopSelection?.type === 'stops'
-          ? kmbDraftStopSelection.stopIds
-          : null
-
-    const containsQuery =
-      kmbQuery?.mode === 'contains'
-        ? kmbQuery.query.trim()
-        : kmbDraftStopSelection?.type === 'contains'
-          ? kmbDraftStopSelection.query.trim()
-          : ''
-
-    let item: FavoritesItem | null = null
-
-    if (stopId) {
-      const stop = kmbStopsById.get(stopId)
-      const fullName = stop ? pickKmbStopTitle(stop, lang) : lang === 'en' ? 'Bus' : '巴士'
-      const { name } = parseKmbStopNameCached(fullName)
-      const title = `${name}${routeSuffix}`
-
-      const idPart = isAdvanced ? `adv:${routeCount}` : (route ?? '__all__')
-      item = {
-        id: `kmb:${stopId}:${idPart}:1`,
-        mode: 'kmb',
-        title,
-        stopId,
-        routeFilterMode,
-        route,
-        serviceType: '1',
-        entries: entriesForSave,
-      }
-    } else if (stopIds && stopIds.length > 0) {
-      const firstStop = stopIds.map((stopId) => kmbStopsById.get(stopId)).find(Boolean)
-      const fullName = firstStop ? pickKmbStopTitle(firstStop, lang) : 'Selected Stops'
-      const { name } = parseKmbStopNameCached(fullName)
-      const title = `${name}${routeSuffix}`
-
-      const idPart = isAdvanced ? `adv:${routeCount}` : (route ?? '__all__')
-      item = {
-        id: `kmb:stops:${stopIds.join(',')}:${idPart}`,
-        mode: 'kmb',
-        title,
-        stopIds,
-        routeFilterMode,
-        route,
-        entries: entriesForSave,
-      }
-    } else if (containsQuery.length >= 3) {
-      const title = `Contains: ${containsQuery}${routeSuffix}`
-
-      const idPart = isAdvanced ? `adv:${routeCount}` : (route ?? '__all__')
-      item = {
-        id: `kmb:contains:${containsQuery}:${idPart}:1`,
-        mode: 'kmb',
-        title,
-        query: containsQuery,
-        routeFilterMode,
-        route,
-        serviceType: '1',
-        entries: entriesForSave,
-      }
-    }
-
-    if (!item) return
-
-    onAddFavorite(item)
-    onAddRecent(item)
-  }
+  const onSave = useKmbSave({
+    lang,
+    routeFilterMode,
+    routeFilter,
+    kmbQuery,
+    kmbDraftStopSelection,
+    kmbStopsById,
+    canFavorite: Boolean(canFavorite),
+    onAddFavorite,
+    onAddRecent,
+  })
 
   const isKeyphraseMode = kmbQuery?.mode === 'contains'
   const querySummary = React.useMemo<KmbPaneState['querySummary']>(() => {

--- a/components/eta/panes/kmb-reducer.ts
+++ b/components/eta/panes/kmb-reducer.ts
@@ -1,0 +1,103 @@
+import type { KmbEtaEntryWithLeg } from '@/lib/eta/client'
+
+export type EtaState = {
+  byStopId: Record<string, KmbEtaEntryWithLeg[]>
+  loadedStopIds: string[]
+  faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
+  loading: boolean
+  error: string | null
+  stale: boolean
+  staleByStopId: Record<string, { stale: boolean; ageMs: number | null }>
+  lastUpdatedAt: number | null
+}
+
+export type EtaAction =
+  | { type: 'REFRESH_START' }
+  | {
+      type: 'REFRESH_SUCCESS'
+      payload: {
+        byStopId: Record<string, KmbEtaEntryWithLeg[]>
+        loadedStopIds: string[]
+        faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>
+      }
+    }
+  | { type: 'REFRESH_ERROR'; error: string }
+  | {
+      type: 'APPEND_STOPS'
+      payload: {
+        byStopId: Record<string, KmbEtaEntryWithLeg[]>
+        newStopIds: string[]
+        faresByVariantKey?: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
+        staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>
+      }
+    }
+  | {
+      type: 'FARES_SUCCESS'
+      payload: {
+        faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
+      }
+    }
+  | { type: 'RESET' }
+
+export const initialEtaState: EtaState = {
+  byStopId: {},
+  loadedStopIds: [],
+  faresByVariantKey: {},
+  loading: false,
+  error: null,
+  stale: false,
+  staleByStopId: {},
+  lastUpdatedAt: null,
+}
+
+export function etaReducer(state: EtaState, action: EtaAction): EtaState {
+  switch (action.type) {
+    case 'REFRESH_START':
+      return { ...state, loading: true, error: null }
+    case 'REFRESH_SUCCESS':
+      return {
+        ...state,
+        byStopId: action.payload.byStopId,
+        loadedStopIds: action.payload.loadedStopIds,
+        faresByVariantKey: action.payload.faresByVariantKey ?? state.faresByVariantKey,
+        loading: false,
+        error: null,
+        stale: Boolean(
+          action.payload.staleByStopId &&
+          Object.values(action.payload.staleByStopId).some((entry) => entry.stale)
+        ),
+        staleByStopId: action.payload.staleByStopId ?? {},
+        lastUpdatedAt: Date.now(),
+      }
+    case 'REFRESH_ERROR':
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+        stale: true,
+        staleByStopId: {},
+      }
+    case 'APPEND_STOPS':
+      return {
+        ...state,
+        byStopId: { ...state.byStopId, ...action.payload.byStopId },
+        loadedStopIds: [...state.loadedStopIds, ...action.payload.newStopIds],
+        faresByVariantKey: {
+          ...state.faresByVariantKey,
+          ...(action.payload.faresByVariantKey ?? {}),
+        },
+        loading: false,
+        staleByStopId: { ...state.staleByStopId, ...(action.payload.staleByStopId ?? {}) },
+      }
+    case 'FARES_SUCCESS':
+      return {
+        ...state,
+        faresByVariantKey: { ...state.faresByVariantKey, ...action.payload.faresByVariantKey },
+      }
+    case 'RESET':
+      return initialEtaState
+    default:
+      return state
+  }
+}

--- a/components/eta/panes/kmb-stop-search.ts
+++ b/components/eta/panes/kmb-stop-search.ts
@@ -1,0 +1,33 @@
+import type { KmbStopSearchItem } from '@/lib/eta/types'
+
+export type StopSearchIndex = {
+  normalizedNames: Map<string, string>
+  version: number
+}
+
+export function buildStopSearchIndex(stops: KmbStopSearchItem[]): StopSearchIndex {
+  const normalizedNames = new Map<string, string>()
+  for (const stop of stops) {
+    const normalized = `${stop.nameEn.toLowerCase()}|${stop.nameTc.toLowerCase()}|${stop.nameSc.toLowerCase()}`
+    normalizedNames.set(stop.stopId, normalized)
+  }
+  return { normalizedNames, version: stops.length }
+}
+
+export function searchStopsByContains(
+  stops: KmbStopSearchItem[],
+  index: StopSearchIndex,
+  query: string
+): string[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return []
+
+  const result: string[] = []
+  for (const stop of stops) {
+    const normalized = index.normalizedNames.get(stop.stopId)
+    if (normalized && normalized.includes(needle)) {
+      result.push(stop.stopId)
+    }
+  }
+  return result
+}

--- a/components/eta/panes/use-kmb-fares.ts
+++ b/components/eta/panes/use-kmb-fares.ts
@@ -1,0 +1,75 @@
+import * as React from 'react'
+
+import { fetchKmbFares, type KmbEtaEntryWithLeg } from '@/lib/eta/client'
+import type { Company } from 'hk-bus-eta'
+
+/**
+ * Manages background fare fetching for KMB ETAs.
+ * Fares are fetched separately from ETAs for faster initial load.
+ */
+export function useKmbFares(
+  dispatchEta: React.Dispatch<{
+    type: 'FARES_SUCCESS'
+    payload: {
+      faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
+    }
+  }>,
+  faresByVariantKeyRef: React.MutableRefObject<
+    Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
+  >
+) {
+  return React.useCallback(
+    (filteredByStopId: Record<string, KmbEtaEntryWithLeg[]>, signal?: AbortSignal) => {
+      const allEtas = Object.entries(filteredByStopId).flatMap(([stopId, etas]) =>
+        etas.map((eta) => ({ stopId, eta }))
+      )
+      const seenVariants = new Set<string>()
+      const fareVariants: {
+        co: Company
+        route: string
+        dir: string
+        serviceType: string
+        stopId: string
+        destCandidates: string[]
+      }[] = []
+
+      for (const { eta } of allEtas) {
+        const co = String(eta.co ?? 'kmb') as Company
+        const route = (eta.route ?? '').toUpperCase()
+        const dir = String(eta.dir ?? '')
+        const serviceType = String(eta.service_type ?? '')
+        const vKey = `${co}|${route}|${dir}|${serviceType}`
+
+        if (faresByVariantKeyRef.current[vKey] || seenVariants.has(vKey)) continue
+        seenVariants.add(vKey)
+
+        fareVariants.push({
+          co,
+          route,
+          dir,
+          serviceType,
+          stopId: String(eta.stop ?? ''),
+          destCandidates: [eta.dest_en, eta.dest_tc, eta.dest_sc].filter(Boolean) as string[],
+        })
+      }
+
+      if (fareVariants.length > 0 && !signal?.aborted) {
+        fetchKmbFares(fareVariants, { signal })
+          .then((faresResult) => {
+            if (!signal?.aborted) {
+              dispatchEta({
+                type: 'FARES_SUCCESS',
+                payload: { faresByVariantKey: faresResult.faresByVariantKey },
+              })
+            }
+          })
+          .catch((err) => {
+            if (!signal?.aborted) {
+              console.warn('Failed to load fares:', err)
+            }
+          })
+      }
+    },
+    [dispatchEta, faresByVariantKeyRef]
+  )
+}

--- a/components/eta/panes/use-kmb-route-filter.ts
+++ b/components/eta/panes/use-kmb-route-filter.ts
@@ -1,0 +1,56 @@
+import type { RouteFilterState } from '@/components/eta/route-filter'
+import type { RouteFilterMode } from '@/lib/store'
+
+/**
+ * Builds a route filter string from the current filter state.
+ * Used to pass to the KMB ETA API.
+ */
+export function buildRouteFilterString(
+  routeFilter: RouteFilterState,
+  routeFilterMode: RouteFilterMode,
+  queryRoute?: string
+): string | undefined {
+  const advancedEntries = routeFilterMode === 'advanced' ? (routeFilter.entries ?? []) : []
+  const requestedRoutes = normalizeKmbRoutesInput(queryRoute?.trim() ?? '')
+
+  if (advancedEntries.length) {
+    const routesFromAdvanced = new Set(
+      advancedEntries.map((e) => e.variantKey.split('|')[1]).filter(Boolean)
+    )
+    return Array.from(routesFromAdvanced).join(',')
+  } else if (requestedRoutes) {
+    return requestedRoutes.join(',')
+  }
+  return undefined
+}
+
+function normalizeKmbRoutesInput(input: string): string[] | null {
+  const requestedRoutes = input
+    ? input
+        .split(',')
+        .map((r) => r.trim())
+        .filter(Boolean)
+        .map((r) => r.toUpperCase())
+    : null
+
+  return requestedRoutes?.length ? requestedRoutes : null
+}
+
+/**
+ * Gets variant keys for a set of stop IDs from the route-stop index.
+ */
+export function getVariantKeysForStops(
+  index: { byStopId: Map<string, Set<string>> },
+  stopIds: string[]
+): string[] {
+  const result = new Set<string>()
+  for (const stopId of stopIds) {
+    const keys = index.byStopId.get(stopId)
+    if (keys) {
+      for (const key of keys) {
+        result.add(key)
+      }
+    }
+  }
+  return Array.from(result)
+}

--- a/components/eta/panes/use-kmb-save.ts
+++ b/components/eta/panes/use-kmb-save.ts
@@ -1,0 +1,154 @@
+import * as React from 'react'
+
+import { parseKmbStopNameCached } from '@/lib/eta/kmb-stop-name'
+import type { KmbStopSearchItem, UiLanguage } from '@/lib/eta/types'
+import type { FavoritesItem, RouteFilterMode } from '@/lib/store'
+import type { RouteFilterState } from '@/components/eta/route-filter'
+
+type KmbQuery =
+  | { mode: 'stop'; stopId: string; route?: string; serviceType?: string }
+  | { mode: 'stops'; stopIds: string[]; route?: string; serviceType?: string }
+  | { mode: 'contains'; query: string; route?: string; serviceType?: string }
+
+type StopSearchSelection =
+  | { type: 'stop'; stopId: string }
+  | { type: 'stops'; stopIds: string[] }
+  | { type: 'contains'; query: string }
+
+function pickKmbStopTitle(stop: KmbStopSearchItem, lang: UiLanguage) {
+  if (lang === 'en') return stop.nameEn
+  if (lang === 'sc') return stop.nameSc
+  return stop.nameTc
+}
+
+type UseKmbSaveOptions = {
+  lang: UiLanguage
+  routeFilterMode: RouteFilterMode
+  routeFilter: RouteFilterState
+  kmbQuery: KmbQuery | null
+  kmbDraftStopSelection: StopSearchSelection | undefined
+  kmbStopsById: Map<string, KmbStopSearchItem>
+  canFavorite: boolean
+  onAddFavorite: (item: FavoritesItem) => void
+  onAddRecent: (item: FavoritesItem) => void
+}
+
+export function useKmbSave({
+  lang,
+  routeFilterMode,
+  routeFilter,
+  kmbQuery,
+  kmbDraftStopSelection,
+  kmbStopsById,
+  canFavorite,
+  onAddFavorite,
+  onAddRecent,
+}: UseKmbSaveOptions) {
+  return React.useCallback(() => {
+    if (!canFavorite) return
+
+    const isAdvanced = routeFilterMode === 'advanced'
+    const routeInput = isAdvanced ? '' : (routeFilter.routes?.trim() ?? '')
+    const route = routeInput || undefined
+
+    const entriesForSave =
+      isAdvanced && routeFilter.entries?.length
+        ? routeFilter.entries.map((e) => ({ variantKey: e.variantKey }))
+        : undefined
+
+    const routeCount = isAdvanced ? (routeFilter.entries?.length ?? 0) : 0
+    const routeSuffix =
+      isAdvanced && routeCount > 0
+        ? ` \u00b7 ${routeCount} ${lang === 'en' ? (routeCount === 1 ? 'route' : 'routes') : '\u689d\u8def\u7dda'}`
+        : route
+          ? ` \u00b7 ${route}`
+          : ''
+
+    const stopId =
+      kmbQuery?.mode === 'stop'
+        ? kmbQuery.stopId
+        : kmbDraftStopSelection?.type === 'stop'
+          ? kmbDraftStopSelection.stopId
+          : null
+
+    const stopIds =
+      kmbQuery?.mode === 'stops'
+        ? kmbQuery.stopIds
+        : kmbDraftStopSelection?.type === 'stops'
+          ? kmbDraftStopSelection.stopIds
+          : null
+
+    const containsQuery =
+      kmbQuery?.mode === 'contains'
+        ? kmbQuery.query.trim()
+        : kmbDraftStopSelection?.type === 'contains'
+          ? kmbDraftStopSelection.query.trim()
+          : ''
+
+    let item: FavoritesItem | null = null
+
+    if (stopId) {
+      const stop = kmbStopsById.get(stopId)
+      const fullName = stop ? pickKmbStopTitle(stop, lang) : lang === 'en' ? 'Bus' : '\u5df4\u58eb'
+      const { name } = parseKmbStopNameCached(fullName)
+      const title = `${name}${routeSuffix}`
+
+      const idPart = isAdvanced ? `adv:${routeCount}` : (route ?? '__all__')
+      item = {
+        id: `kmb:${stopId}:${idPart}:1`,
+        mode: 'kmb',
+        title,
+        stopId,
+        routeFilterMode,
+        route,
+        serviceType: '1',
+        entries: entriesForSave,
+      }
+    } else if (stopIds && stopIds.length > 0) {
+      const firstStop = stopIds.map((stopId) => kmbStopsById.get(stopId)).find(Boolean)
+      const fullName = firstStop ? pickKmbStopTitle(firstStop, lang) : 'Selected Stops'
+      const { name } = parseKmbStopNameCached(fullName)
+      const title = `${name}${routeSuffix}`
+
+      const idPart = isAdvanced ? `adv:${routeCount}` : (route ?? '__all__')
+      item = {
+        id: `kmb:stops:${stopIds.join(',')}:${idPart}`,
+        mode: 'kmb',
+        title,
+        stopIds,
+        routeFilterMode,
+        route,
+        entries: entriesForSave,
+      }
+    } else if (containsQuery.length >= 3) {
+      const title = `Contains: ${containsQuery}${routeSuffix}`
+
+      const idPart = isAdvanced ? `adv:${routeCount}` : (route ?? '__all__')
+      item = {
+        id: `kmb:contains:${containsQuery}:${idPart}:1`,
+        mode: 'kmb',
+        title,
+        query: containsQuery,
+        routeFilterMode,
+        route,
+        serviceType: '1',
+        entries: entriesForSave,
+      }
+    }
+
+    if (!item) return
+
+    onAddFavorite(item)
+    onAddRecent(item)
+  }, [
+    lang,
+    routeFilterMode,
+    routeFilter,
+    kmbQuery,
+    kmbDraftStopSelection,
+    kmbStopsById,
+    canFavorite,
+    onAddFavorite,
+    onAddRecent,
+  ])
+}


### PR DESCRIPTION
Closes #62

Extracted logical modules from kmb-pane.tsx (1657 → 1370 lines):

- **kmb-reducer.ts** (103 lines) - EtaState types, initial state, and reducer
- **kmb-stop-search.ts** (33 lines) - Stop search index building and contains search
- **use-kmb-route-filter.ts** (56 lines) - Route filter string builder and variant key utilities
- **use-kmb-save.ts** (156 lines) - Save/favorite logic extracted into a hook
- **use-kmb-fares.ts** (74 lines) - Background fare fetching hook

No functionality changed - pure extraction.