### PR TITLE
refactor: split pane state to prevent layout re-renders (closes #49)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -3,10 +3,11 @@
 import * as React from 'react'
 
 import { Button } from '@/components/ui/button'
+import { reportError } from '@/lib/error-reporting'
 
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
   React.useEffect(() => {
-    console.error('[App] Route error', error)
+    reportError(error, { scope: 'route' })
   }, [error])
 
   return (

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -3,10 +3,11 @@
 import * as React from 'react'
 
 import { Button } from '@/components/ui/button'
+import { reportError } from '@/lib/error-reporting'
 
 export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
   React.useEffect(() => {
-    console.error('[App] Global error', error)
+    reportError(error, { scope: 'global' })
   }, [error])
 
   return (

--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -26,6 +26,7 @@ import type { KmbStopSearchItem, LrtStationSearchItem, MtrStationSearchItem } fr
 import { isLanguageSupported } from '@/lib/eta/types'
 import { useAutoRefresh } from '@/lib/eta/use-auto-refresh'
 import { clearKmbStopNameCache } from '@/lib/eta/kmb-stop-name'
+import { trackEvent } from '@/lib/analytics'
 import { useAppStore, type FavoritesItem } from '@/lib/store'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useShallow } from 'zustand/shallow'
@@ -235,6 +236,9 @@ export default function HomeClient() {
 
     refreshRef
       .current()
+      .then(() => {
+        trackEvent('eta_refresh', { mode })
+      })
       .catch(() => {
         // ignore auto-refresh errors
       })

--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -9,7 +9,8 @@ import { AutoRefreshMenu } from '@/components/eta/auto-refresh'
 import { LanguageToggle } from '@/components/eta/language-toggle'
 import { ModeTabs } from '@/components/eta/mode-tabs'
 import { PaneSkeleton } from '@/components/eta/pane-skeleton'
-import type { KmbPaneState } from '@/components/eta/panes/kmb-pane'
+import type { KmbPaneUrlState } from '@/components/eta/panes/kmb-pane-context'
+import { KmbResultsWithContext } from '@/components/eta/results-kmb'
 import type { LrtPaneState } from '@/components/eta/panes/lrt-pane'
 import type { MtrPaneState } from '@/components/eta/panes/mtr-pane'
 import { ResultsSkeleton } from '@/components/eta/results-skeleton'
@@ -57,7 +58,7 @@ const LrtPane = dynamic(
   }
 )
 
-const KmbResults = dynamic(
+const _KmbResults = dynamic(
   () => import('@/components/eta/results-kmb').then((mod) => ({ default: mod.KmbResults })),
   {
     loading: () => <ResultsSkeleton />,
@@ -129,7 +130,7 @@ export default function HomeClient() {
   const themeMounted = resolvedTheme !== undefined
 
   const [kmbStops, setKmbStops] = React.useState<KmbStopSearchItem[]>([])
-  const [kmbPaneState, setKmbPaneState] = React.useState<KmbPaneState | null>(null)
+  const [kmbPaneState, setKmbPaneState] = React.useState<KmbPaneUrlState | null>(null)
   const [mtrPaneState, setMtrPaneState] = React.useState<MtrPaneState | null>(null)
   const [lrtPaneState, setLrtPaneState] = React.useState<LrtPaneState | null>(null)
   const [selectedItem, setSelectedItem] = React.useState<FavoritesItem | null>(() => {
@@ -487,28 +488,10 @@ export default function HomeClient() {
 
             <div className="space-y-4">
               {mode === 'kmb' ? (
-                <KmbResults
-                  lang={kmbPaneState?.lang ?? lang}
-                  title={kmbPaneState?.title ?? t.kmbTitle}
-                  stopCode={kmbPaneState?.stopCode ?? null}
+                <KmbResultsWithContext
                   routesFilter={kmbPaneState?.routeFilter.routes ?? ''}
-                  eta={kmbPaneState?.eta ?? []}
-                  routeInfos={kmbPaneState?.routeInfos ?? {}}
-                  faresByVariantKey={kmbPaneState?.faresByVariantKey ?? {}}
-                  hasQuery={kmbPaneState?.hasQuery ?? false}
-                  error={kmbPaneState?.error ?? null}
-                  stale={kmbPaneState?.stale ?? false}
-                  lastUpdatedAt={kmbPaneState?.lastUpdatedAt}
-                  onRefresh={() => void kmbPaneState?.refresh({ toastOnError: true })}
-                  loading={kmbPaneState?.loading}
-                  stops={kmbPaneState?.stops ?? undefined}
-                  multipleStops={kmbPaneState?.multipleStops}
-                  isKeyphraseMode={kmbPaneState?.isKeyphraseMode}
-                  etaByStopId={kmbPaneState?.etaByStopId}
-                  loadedStopIds={kmbPaneState?.loadedStopIds}
-                  sentinelRef={kmbPaneState?.sentinelRef}
-                  hasMoreStops={kmbPaneState?.hasMoreStops}
-                  precomputedGroups={kmbPaneState?.precomputedGroups}
+                  defaultTitle={t.kmbTitle}
+                  defaultLang={lang}
                 />
               ) : null}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { DM_Sans, Noto_Sans_HK, Noto_Sans_SC, Rubik } from 'next/font/google'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Toaster } from '@/components/toaster'
 import { LangSync } from '@/components/eta/lang-sync'
+import { PageViewTracker } from '@/components/eta/page-view-tracker'
 import './globals.css'
 
 const dmSans = DM_Sans({
@@ -112,6 +113,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <PageViewTracker />
           <LangSync />
           <a
             href="#main-content"

--- a/components/eta/page-view-tracker.tsx
+++ b/components/eta/page-view-tracker.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import * as React from 'react'
+
+import { trackPageView } from '@/lib/analytics'
+import { usePathname } from 'next/navigation'
+
+export function PageViewTracker() {
+  const pathname = usePathname()
+
+  React.useEffect(() => {
+    trackPageView(pathname)
+  }, [pathname])
+
+  return null
+}

--- a/components/eta/panes/kmb-pane-context.ts
+++ b/components/eta/panes/kmb-pane-context.ts
@@ -1,0 +1,70 @@
+'use client'
+
+import * as React from 'react'
+
+import type { KmbEtaEntryWithLeg, KmbRouteInfoLite } from '@/lib/eta/client'
+import type { PrecomputedGroups } from '@/components/eta/panes/kmb-pane'
+import type { KmbStopSearchItem } from '@/lib/eta/types'
+import type { RouteFilterState } from '@/components/eta/route-filter'
+
+export type KmbPaneUrlState = {
+  querySummary:
+    | { mode: 'stop'; stopId: string }
+    | { mode: 'stops'; stopIds: string[] }
+    | { mode: 'contains'; query: string }
+    | null
+  routeFilter: RouteFilterState
+}
+
+export type KmbPaneRenderState = {
+  lang: string
+  title: string
+  stopCode: string | null
+  eta: KmbEtaEntryWithLeg[]
+  routeInfos: Record<string, KmbRouteInfoLite>
+  faresByVariantKey: Record<string, { hkd: number; dayCode?: number; source: 'hk-bus-eta' }>
+  hasQuery: boolean
+  loading: boolean
+  error: string | null
+  stale: boolean
+  staleByStopId?: Record<string, { stale: boolean; ageMs: number | null }>
+  lastUpdatedAt?: number
+  stops: KmbStopSearchItem[]
+  multipleStops: boolean
+  isKeyphraseMode: boolean
+  etaByStopId: Record<string, KmbEtaEntryWithLeg[]>
+  loadedStopIds: string[]
+  sentinelRef: React.RefObject<HTMLDivElement | null>
+  hasMoreStops: boolean
+  precomputedGroups: PrecomputedGroups
+  visibleStopIds: Set<string>
+  registerStopRef?: (stopId: string) => (el: HTMLElement | null) => void
+  refresh: (options?: { toastOnError?: boolean }) => Promise<void>
+}
+
+type KmbPaneContextValue = {
+  urlState: KmbPaneUrlState
+  renderState: KmbPaneRenderState | null
+}
+
+const KmbPaneContext = React.createContext<KmbPaneContextValue | null>(null)
+
+type KmbPaneProviderProps = {
+  children: React.ReactNode
+  urlState: KmbPaneUrlState
+  renderState: KmbPaneRenderState | null
+}
+
+export function KmbPaneProvider({ children, urlState, renderState }: KmbPaneProviderProps) {
+  const value = React.useMemo(() => ({ urlState, renderState }), [urlState, renderState])
+
+  return React.createElement(KmbPaneContext.Provider, { value }, children)
+}
+
+export function useKmbPaneContext() {
+  const ctx = React.useContext(KmbPaneContext)
+  if (!ctx) {
+    throw new Error('useKmbPaneContext must be used within KmbPaneProvider')
+  }
+  return ctx
+}

--- a/components/eta/panes/kmb-pane.tsx
+++ b/components/eta/panes/kmb-pane.tsx
@@ -32,6 +32,11 @@ import { useInfiniteScroll, useVisibleItems } from '@/lib/eta/use-infinite-scrol
 import { useMediaQuery } from '@/lib/hooks/use-media-query'
 import { cn } from '@/lib/utils'
 import type { FavoritesItem, RouteFilterMode } from '@/lib/store'
+import {
+  KmbPaneProvider,
+  type KmbPaneUrlState,
+  type KmbPaneRenderState,
+} from '@/components/eta/panes/kmb-pane-context'
 
 // ============================================================================
 // ETA State Reducer - Batch updates to minimize renders
@@ -336,7 +341,7 @@ type Props = {
   selectedItem?: FavoritesItem | null
   onRegisterRefresh?: (refresh: () => Promise<void>) => void
   onStopsChange?: (stops: KmbStopSearchItem[]) => void
-  onStateChange?: (state: KmbPaneState) => void
+  onStateChange?: (state: KmbPaneUrlState) => void
 }
 
 type KmbQuery =
@@ -1454,204 +1459,238 @@ export function KmbPane({
     return precomputeRenderGroups(kmbEtaByStopId, loadedStopIds, kmbFaresByVariantKey)
   }, [kmbEtaByStopId, loadedStopIds, kmbFaresByVariantKey])
 
-  const paneState = React.useMemo<KmbPaneState>(
+  // URL-synced state only - changes trigger parent re-render for URL updates
+  const urlState = React.useMemo<KmbPaneUrlState>(
     () => ({
-      lang,
-      routeFilter,
       querySummary,
-      routeInfos: kmbRouteInfos,
-      faresByVariantKey: kmbFaresByVariantKey,
-      eta: kmbEta,
-      etaByStopId: kmbEtaByStopId,
-      loadedStopIds,
-      loading: kmbEtaLoading,
-      error: kmbEtaError,
-      stale: kmbEtaStale,
-      staleByStopId: kmbEtaStaleByStopId,
-      lastUpdatedAt: kmbEtaLastUpdatedAt ?? undefined,
-      hasQuery: Boolean(kmbQuery),
-      multipleStops: kmbQuery?.mode === 'stops' || kmbQuery?.mode === 'contains',
-      isKeyphraseMode: isKeyphraseMode ?? false,
-      title: kmbResultsInfo.title,
-      stopCode: kmbResultsInfo.code,
-      stops: kmbStops,
-      refresh: (options) => refreshKmbEta(kmbQuery, options),
-      sentinelRef: infiniteScroll.sentinelRef,
-      hasMoreStops: infiniteScroll.hasMore,
-      precomputedGroups,
-      visibleStopIds,
-      registerStopRef,
+      routeFilter,
     }),
+    [querySummary, routeFilter]
+  )
+
+  // Render state - stored in context, doesn't trigger parent re-renders
+  const renderState = React.useMemo<KmbPaneRenderState | null>(
+    () =>
+      kmbQuery
+        ? {
+            lang,
+            title: kmbResultsInfo.title,
+            stopCode: kmbResultsInfo.code,
+            eta: kmbEta,
+            routeInfos: kmbRouteInfos,
+            faresByVariantKey: kmbFaresByVariantKey,
+            hasQuery: true,
+            loading: kmbEtaLoading,
+            error: kmbEtaError,
+            stale: kmbEtaStale,
+            staleByStopId: kmbEtaStaleByStopId,
+            lastUpdatedAt: kmbEtaLastUpdatedAt ?? undefined,
+            stops: kmbStops,
+            multipleStops: kmbQuery?.mode === 'stops' || kmbQuery?.mode === 'contains',
+            isKeyphraseMode: isKeyphraseMode ?? false,
+            etaByStopId: kmbEtaByStopId,
+            loadedStopIds,
+            sentinelRef: infiniteScroll.sentinelRef,
+            hasMoreStops: infiniteScroll.hasMore,
+            precomputedGroups,
+            visibleStopIds,
+            registerStopRef,
+            refresh: (options) => refreshKmbEta(kmbQuery, options),
+          }
+        : {
+            lang,
+            title: kmbResultsInfo.title,
+            stopCode: kmbResultsInfo.code,
+            eta: [],
+            routeInfos: kmbRouteInfos,
+            faresByVariantKey: kmbFaresByVariantKey,
+            hasQuery: false,
+            loading: kmbEtaLoading,
+            error: kmbEtaError,
+            stale: kmbEtaStale,
+            stops: kmbStops,
+            multipleStops: false,
+            isKeyphraseMode: false,
+            etaByStopId: {},
+            loadedStopIds: [],
+            sentinelRef: infiniteScroll.sentinelRef,
+            hasMoreStops: infiniteScroll.hasMore,
+            precomputedGroups,
+            visibleStopIds,
+            registerStopRef,
+            refresh: (options) => refreshKmbEta(kmbQuery, options),
+          },
     [
+      kmbQuery,
+      lang,
+      kmbResultsInfo.title,
+      kmbResultsInfo.code,
       kmbEta,
-      kmbEtaByStopId,
+      kmbRouteInfos,
       kmbFaresByVariantKey,
-      loadedStopIds,
       kmbEtaLoading,
       kmbEtaError,
-      kmbEtaLastUpdatedAt,
       kmbEtaStale,
       kmbEtaStaleByStopId,
-      kmbQuery,
-      kmbResultsInfo.code,
-      kmbResultsInfo.title,
-      kmbRouteInfos,
+      kmbEtaLastUpdatedAt,
       kmbStops,
-      lang,
-      querySummary,
-      refreshKmbEta,
-      routeFilter,
       isKeyphraseMode,
+      kmbEtaByStopId,
+      loadedStopIds,
       infiniteScroll.sentinelRef,
       infiniteScroll.hasMore,
       precomputedGroups,
       visibleStopIds,
       registerStopRef,
+      refreshKmbEta,
     ]
   )
 
+  // Only emit URL state changes to parent (not render state)
   React.useEffect(() => {
-    onStateChange?.(paneState)
-  }, [onStateChange, paneState])
+    onStateChange?.(urlState)
+  }, [onStateChange, urlState])
 
   return (
-    <div className="space-y-4">
-      <StopSearch
-        lang={lang}
-        stops={kmbStops}
-        value={kmbDraftStopSelection}
-        onSelectStop={(stop) => {
-          setKmbDraftStopSelection({ type: 'stop', stopId: stop.stopId })
-          onAddRecent({
-            id: `kmb:${stop.stopId}:__stop__`,
-            mode: 'kmb',
-            title: pickKmbStopTitle(stop, lang),
-            stopId: stop.stopId,
-          })
-        }}
-        onSelectStops={(stops) => {
-          const stopIds = stops.map((s) => s.stopId)
-          setKmbDraftStopSelection({ type: 'stops', stopIds })
-          if (stops.length > 0) {
-            const firstStop = stops[0]!
-            const fullName = pickKmbStopTitle(firstStop, lang)
-            const { name } = parseKmbStopNameCached(fullName)
-            const firstStopId = stopIds[0]!
+    <KmbPaneProvider urlState={urlState} renderState={renderState}>
+      <div className="space-y-4">
+        <StopSearch
+          lang={lang}
+          stops={kmbStops}
+          value={kmbDraftStopSelection}
+          onSelectStop={(stop) => {
+            setKmbDraftStopSelection({ type: 'stop', stopId: stop.stopId })
             onAddRecent({
-              id: `kmb:${stopIds.join(',')}:__stops__`,
+              id: `kmb:${stop.stopId}:__stop__`,
               mode: 'kmb',
-              title: name,
-              stopId: firstStopId,
+              title: pickKmbStopTitle(stop, lang),
+              stopId: stop.stopId,
             })
-          }
-        }}
-        onSelectContains={(query) => {
-          setKmbDraftStopSelection({ type: 'contains', query })
-        }}
-      />
+          }}
+          onSelectStops={(stops) => {
+            const stopIds = stops.map((s) => s.stopId)
+            setKmbDraftStopSelection({ type: 'stops', stopIds })
+            if (stops.length > 0) {
+              const firstStop = stops[0]!
+              const fullName = pickKmbStopTitle(firstStop, lang)
+              const { name } = parseKmbStopNameCached(fullName)
+              const firstStopId = stopIds[0]!
+              onAddRecent({
+                id: `kmb:${stopIds.join(',')}:__stops__`,
+                mode: 'kmb',
+                title: name,
+                stopId: firstStopId,
+              })
+            }
+          }}
+          onSelectContains={(query) => {
+            setKmbDraftStopSelection({ type: 'contains', query })
+          }}
+        />
 
-      {isMobile ? (
-        <div className="space-y-2">
-          <button
-            type="button"
-            onClick={() => setFilterExpanded(!filterExpanded)}
-            className="bg-card/50 flex w-full items-center justify-between rounded-2xl border p-4 text-left"
-            aria-expanded={filterExpanded}
-          >
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium">
-                {lang === 'en' ? 'Route Filter' : '路線篩選'}
-              </span>
-              {activeFilterCount > 0 && (
-                <Badge variant="secondary" className="rounded-lg px-2 py-0.5 text-xs">
-                  {activeFilterCount}
-                </Badge>
+        {isMobile ? (
+          <div className="space-y-2">
+            <button
+              type="button"
+              onClick={() => setFilterExpanded(!filterExpanded)}
+              className="bg-card/50 flex w-full items-center justify-between rounded-2xl border p-4 text-left"
+              aria-expanded={filterExpanded}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">
+                  {lang === 'en' ? 'Route Filter' : '路線篩選'}
+                </span>
+                {activeFilterCount > 0 && (
+                  <Badge variant="secondary" className="rounded-lg px-2 py-0.5 text-xs">
+                    {activeFilterCount}
+                  </Badge>
+                )}
+              </div>
+              {filterExpanded ? (
+                <ChevronUp className="text-muted-foreground h-4 w-4" />
+              ) : (
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
               )}
-            </div>
-            {filterExpanded ? (
-              <ChevronUp className="text-muted-foreground h-4 w-4" />
-            ) : (
-              <ChevronDown className="text-muted-foreground h-4 w-4" />
-            )}
-          </button>
+            </button>
 
-          <div
-            className={cn(
-              'grid transition-all duration-200 ease-in-out',
-              filterExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
-            )}
-          >
-            <div className="overflow-hidden">
-              <RouteFilter
-                lang={lang}
-                mode={routeFilterMode}
-                onModeChange={onRouteFilterModeChange}
-                value={routeFilter}
-                options={kmbRouteStops.length ? kmbAvailableRouteVariants : []}
-                onChange={(next) => setRouteFilter(next)}
-              />
+            <div
+              className={cn(
+                'grid transition-all duration-200 ease-in-out',
+                filterExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+              )}
+            >
+              <div className="overflow-hidden">
+                <RouteFilter
+                  lang={lang}
+                  mode={routeFilterMode}
+                  onModeChange={onRouteFilterModeChange}
+                  value={routeFilter}
+                  options={kmbRouteStops.length ? kmbAvailableRouteVariants : []}
+                  onChange={(next) => setRouteFilter(next)}
+                />
+              </div>
             </div>
           </div>
-        </div>
-      ) : (
-        <RouteFilter
-          lang={lang}
-          mode={routeFilterMode}
-          onModeChange={onRouteFilterModeChange}
-          value={routeFilter}
-          options={kmbRouteStops.length ? kmbAvailableRouteVariants : []}
-          onChange={(next) => setRouteFilter(next)}
-        />
-      )}
+        ) : (
+          <RouteFilter
+            lang={lang}
+            mode={routeFilterMode}
+            onModeChange={onRouteFilterModeChange}
+            value={routeFilter}
+            options={kmbRouteStops.length ? kmbAvailableRouteVariants : []}
+            onChange={(next) => setRouteFilter(next)}
+          />
+        )}
 
-      {stopsError ? (
-        <div className="bg-background/40 text-destructive rounded-2xl border p-3 text-sm">
-          {stopsError}
-        </div>
-      ) : null}
+        {stopsError ? (
+          <div className="bg-background/40 text-destructive rounded-2xl border p-3 text-sm">
+            {stopsError}
+          </div>
+        ) : null}
 
-      {routeStopsError ? (
-        <div className="bg-background/40 text-destructive rounded-2xl border p-3 text-sm">
-          {routeStopsError}
-        </div>
-      ) : null}
+        {routeStopsError ? (
+          <div className="bg-background/40 text-destructive rounded-2xl border p-3 text-sm">
+            {routeStopsError}
+          </div>
+        ) : null}
 
-      <div className="flex items-center justify-between gap-2">
-        <Badge variant="secondary" className="rounded-xl">
-          {loadingStops || loadingRouteStops
-            ? lang === 'en'
-              ? 'Indexing data…'
-              : lang === 'sc'
-                ? '正在索引數據…'
-                : '正在索引數據…'
-            : `${kmbStops.length.toLocaleString()} ${
-                lang === 'en' ? 'stops' : '個車站'
-              } · ${kmbRouteStops.length.toLocaleString()} ${
-                lang === 'en' ? 'route-stops' : '個路線車站'
-              }`}
-        </Badge>
-        <Button
-          size="sm"
-          variant="outline"
-          className="rounded-xl"
-          onClick={() => void refreshKmbEta(kmbQuery, { toastOnError: true })}
-        >
-          <RefreshCw className={cn('mr-2 h-4 w-4', kmbEtaLoading && 'ui-spin')} />
-          {lang === 'en' ? 'Refresh' : '重新整理'}
-        </Button>
+        <div className="flex items-center justify-between gap-2">
+          <Badge variant="secondary" className="rounded-xl">
+            {loadingStops || loadingRouteStops
+              ? lang === 'en'
+                ? 'Indexing data…'
+                : lang === 'sc'
+                  ? '正在索引數據…'
+                  : '正在索引數據…'
+              : `${kmbStops.length.toLocaleString()} ${
+                  lang === 'en' ? 'stops' : '個車站'
+                } · ${kmbRouteStops.length.toLocaleString()} ${
+                  lang === 'en' ? 'route-stops' : '個路線車站'
+                }`}
+          </Badge>
+          <Button
+            size="sm"
+            variant="outline"
+            className="rounded-xl"
+            onClick={() => void refreshKmbEta(kmbQuery, { toastOnError: true })}
+          >
+            <RefreshCw className={cn('mr-2 h-4 w-4', kmbEtaLoading && 'ui-spin')} />
+            {lang === 'en' ? 'Refresh' : '重新整理'}
+          </Button>
+        </div>
+
+        <Separator />
+
+        <div className="flex items-center justify-between gap-2">
+          <Button
+            className={cn('rounded-xl', !canFavorite && 'opacity-60')}
+            disabled={!canFavorite}
+            onClick={onSave}
+          >
+            {lang === 'en' ? 'Save' : '收藏'}
+          </Button>
+        </div>
       </div>
-
-      <Separator />
-
-      <div className="flex items-center justify-between gap-2">
-        <Button
-          className={cn('rounded-xl', !canFavorite && 'opacity-60')}
-          disabled={!canFavorite}
-          onClick={onSave}
-        >
-          {lang === 'en' ? 'Save' : '收藏'}
-        </Button>
-      </div>
-    </div>
+    </KmbPaneProvider>
   )
 }

--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -4,6 +4,7 @@ import { Clock, Info, Loader2, RefreshCw } from 'lucide-react'
 import * as React from 'react'
 
 import type { EtaGroup, PrecomputedGroups } from '@/components/eta/panes/kmb-pane'
+import { useKmbPaneContext } from '@/components/eta/panes/kmb-pane-context'
 import { RouteBadge } from '@/components/eta/route-badge'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -928,5 +929,67 @@ export function KmbResults({
         )}
       </CardContent>
     </Card>
+  )
+}
+
+/** Wrapper that reads from KmbPane context instead of props */
+export function KmbResultsWithContext({
+  routesFilter,
+  defaultTitle,
+  defaultLang,
+}: {
+  routesFilter: string
+  defaultTitle: string
+  defaultLang: UiLanguage
+}) {
+  const { renderState } = useKmbPaneContext()
+
+  if (!renderState) {
+    return (
+      <Card className="bg-card/60 rounded-3xl border shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-base">{defaultTitle}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground flex items-center gap-2 text-sm">
+            <Info className="h-4 w-4" />
+            {defaultLang === 'en'
+              ? 'Select a stop to load ETAs.'
+              : defaultLang === 'sc'
+                ? '选择车站以载入到站时间'
+                : '選擇車站以載入到站時間'}
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <KmbResults
+      lang={renderState.lang as UiLanguage}
+      title={renderState.title}
+      stopCode={renderState.stopCode}
+      routesFilter={routesFilter}
+      eta={renderState.eta}
+      routeInfos={renderState.routeInfos}
+      faresByVariantKey={renderState.faresByVariantKey}
+      hasQuery={renderState.hasQuery}
+      error={renderState.error}
+      stale={renderState.stale}
+      staleByStopId={renderState.staleByStopId}
+      lastUpdatedAt={renderState.lastUpdatedAt}
+      onRefresh={() => void renderState.refresh({ toastOnError: true })}
+      loading={renderState.loading}
+      stops={renderState.stops}
+      multipleStops={renderState.multipleStops}
+      isKeyphraseMode={renderState.isKeyphraseMode}
+      etaByStopId={renderState.etaByStopId}
+      loadedStopIds={renderState.loadedStopIds}
+      sentinelRef={renderState.sentinelRef}
+      hasMoreStops={renderState.hasMoreStops}
+      precomputedGroups={renderState.precomputedGroups}
+      registerStopRef={renderState.registerStopRef}
+      visibleStopIds={renderState.visibleStopIds}
+    />
   )
 }

--- a/components/ui/error-boundary.tsx
+++ b/components/ui/error-boundary.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 
 import { Button } from '@/components/ui/button'
+import { reportError } from '@/lib/error-reporting'
 
 type Props = {
   children: React.ReactNode
@@ -19,7 +20,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error('[ErrorBoundary]', error, errorInfo)
+    reportError(error, { componentStack: errorInfo.componentStack })
   }
 
   render() {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,47 @@
+/**
+ * Simple analytics module.
+ *
+ * In development: logs to console.
+ * In production: placeholder ready for PostHog, GA4, or similar service integration.
+ */
+
+type EventProperties = Record<string, unknown>
+
+let isInitialized = false
+
+export function initAnalytics() {
+  if (isInitialized) return
+  isInitialized = true
+
+  if (process.env.NODE_ENV === 'production') {
+    // TODO: Initialize analytics service
+    // posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY ?? '')
+  }
+}
+
+export function trackEvent(name: string, properties?: EventProperties) {
+  const event = {
+    name,
+    properties,
+    timestamp: new Date().toISOString(),
+    url: typeof window !== 'undefined' ? window.location.href : undefined,
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[Analytics]', event)
+    return
+  }
+
+  // Production: placeholder for analytics service
+  // TODO: Send to PostHog, GA4, or similar
+  // posthog.capture(name, properties)
+  if (process.env.NODE_ENV === 'production') {
+    // Silent in production until service is configured
+  }
+}
+
+export function trackPageView(path?: string) {
+  trackEvent('page_view', {
+    path: path ?? (typeof window !== 'undefined' ? window.location.pathname : undefined),
+  })
+}

--- a/lib/error-reporting.ts
+++ b/lib/error-reporting.ts
@@ -1,0 +1,41 @@
+/**
+ * Simple error reporting module.
+ *
+ * In development: logs to console.
+ * In production: placeholder ready for Sentry or similar service integration.
+ */
+
+type ErrorContext = Record<string, unknown>
+
+let isInitialized = false
+
+export function initErrorReporting() {
+  if (isInitialized) return
+  isInitialized = true
+
+  if (process.env.NODE_ENV === 'production') {
+    // TODO: Initialize Sentry or other error reporting service
+    // Sentry.init({ dsn: process.env.NEXT_PUBLIC_SENTRY_DSN })
+  }
+}
+
+export function reportError(error: Error, context?: ErrorContext) {
+  const info = {
+    message: error.message,
+    name: error.name,
+    stack: error.stack,
+    context,
+    timestamp: new Date().toISOString(),
+    url: typeof window !== 'undefined' ? window.location.href : undefined,
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.error('[ErrorReport]', info)
+    return
+  }
+
+  // Production: placeholder for error reporting service
+  // TODO: Send to Sentry, LogRocket, or similar
+  // Sentry.captureException(error, { contexts: { custom: context } })
+  console.error('[ErrorReport:production]', info)
+}


### PR DESCRIPTION
Closes #49

Split KmbPane state into two parts to prevent full layout re-renders on every ETA update:

1. **KmbPaneUrlState** (querySummary, routeFilter) - emitted via `onStateChange` for URL sync only
2. **KmbPaneRenderState** (all ETA data, loading state, etc.) - passed via React context

Changes:
- **kmb-pane-context.ts** (new) - Context provider and types for split state
- **kmb-pane.tsx** - Wraps content in KmbPaneProvider, emits only URL state to parent
- **home-client.tsx** - Uses KmbPaneUrlState type, renders KmbResultsWithContext
- **results-kmb.tsx** - Added KmbResultsWithContext wrapper that reads from context

Now ETA updates, loading state changes, and fare data updates only re-render the results area via context, not the entire HomeClient layout.