### PR TITLE
fix(i18n): move desc and searchPin from kmb to common namespace

### DIFF
--- a/lib/eta/i18n.ts
+++ b/lib/eta/i18n.ts
@@ -34,10 +34,6 @@ const common: Record<string, TranslationEntry> = {
   details: { en: 'Details', tc: '詳情', sc: '详情' },
   now: { en: 'Now', tc: '即將到達', sc: '即将到达' },
   arriving: { en: 'Arriving', tc: '即將到達', sc: '即将到达' },
-}
-
-const kmb: Record<string, TranslationEntry> = {
-  title: { en: 'Bus ETAs', tc: '巴士到站預報', sc: '巴士到站预报' },
   desc: {
     en: 'Clean, fast ETAs for Hong Kong transit.',
     tc: '簡潔又快速的香港交通到站預報。',
@@ -48,6 +44,10 @@ const kmb: Record<string, TranslationEntry> = {
     tc: '搜尋並釘選常用車站。',
     sc: '搜索并钉选常用车站。',
   },
+}
+
+const kmb: Record<string, TranslationEntry> = {
+  title: { en: 'Bus ETAs', tc: '巴士到站預報', sc: '巴士到站预报' },
   allRoutesAtStop: { en: 'All routes at this stop', tc: '此站所有路線', sc: '此站所有路线' },
   filtered: { en: 'Filtered:', tc: '篩選:', sc: '筛选:' },
   stopsLoaded: { en: 'stops loaded', tc: '個車站', sc: '个车站' },


### PR DESCRIPTION
## Problem

Since commit 3287282, the strings `common.desc` and `common.searchPin` render literally instead of their translated values on the home page.

## Root cause

The `desc` and `searchPin` translation entries were placed under the `kmb` namespace in `lib/eta/i18n.ts`, but `app/home-client.tsx` references them as `t('common.desc')` and `t('common.searchPin')`. The `t()` function splits on `.`, looks up `translations['common']['desc']`, finds nothing, and falls back to returning the raw key.

## Fix

Moved `desc` and `searchPin` from the `kmb` block to the `common` block in `lib/eta/i18n.ts`. These are mode-agnostic app taglines ("Clean, fast ETAs for Hong Kong transit."), not KMB-specific.

## Verification

- `bun run lint` — passes (1 pre-existing warning in coverage artifact)
- `bun run test` — all 152 tests pass