### PR TITLE
Refactor MTR results to collapsed-first line cards

### DIFF
--- a/components/eta/expandable-eta-row.tsx
+++ b/components/eta/expandable-eta-row.tsx
@@ -27,8 +27,7 @@ export function ExpandableEtaRow({ expanded, onToggle, color, className, childre
 
   return (
     <motion.div
-      layout
-      transition={{ duration: 0.2, ease: [0.2, 0.8, 0.2, 1] }}
+      transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
       className={cn(
         'bg-surface-container relative overflow-hidden rounded-2xl',
         'hover:bg-surface-container-high focus-within:ring-primary/30 focus-within:ring-2 focus-within:outline-none',
@@ -60,7 +59,7 @@ export function ExpandableEtaRow({ expanded, onToggle, color, className, childre
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2, ease: [0.2, 0.8, 0.2, 1] }}
+            transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
             className="overflow-hidden"
           >
             <div className="pointer-events-none relative z-10 pr-3 pb-3 pl-4">{panel}</div>

--- a/components/eta/results-mtr.tsx
+++ b/components/eta/results-mtr.tsx
@@ -4,13 +4,12 @@ import * as React from 'react'
 import { ChevronDown, ChevronUp, ExternalLink, Info, RefreshCw, TrainFront } from 'lucide-react'
 
 import { LivePulse } from '@/components/m3/motion'
-import { Badge } from '@/components/ui/badge'
 import { Marquee } from '@/components/ui/marquee'
 import { findMtrStationBySta } from '@/lib/data/mtr-stations'
 import { getLineColor } from '@/lib/eta/line-colors'
 import { formatUiTime } from '@/lib/eta/format'
 import { formatRelativeAgeLabel, isStaleByAge } from '@/lib/eta/stale'
-import type { MtrScheduleResponse } from '@/lib/eta/mtr'
+import type { MtrScheduleResponse, MtrTrainEntry } from '@/lib/eta/mtr'
 import type { UiLanguage } from '@/lib/eta/types'
 import { getReadableForeground } from '@/lib/ui/color'
 import { cn } from '@/lib/utils'
@@ -96,6 +95,206 @@ function formatPlatform(plat: unknown) {
   const raw = String(plat ?? '').trim()
   if (!raw) return ''
   return raw
+}
+
+type MtrLineCardProps = {
+  payload: {
+    UP?: MtrTrainEntry[]
+    DOWN?: MtrTrainEntry[]
+  }
+  line: string
+  sta: string
+  lang: UiLanguage
+  lineColor?: string
+  upLabel: string
+  downLabel: string
+  expanded: boolean
+  onToggle: () => void
+  staggerClass?: string
+}
+
+function MtrLineCard({
+  payload,
+  line,
+  sta,
+  lang,
+  lineColor,
+  upLabel,
+  downLabel,
+  expanded,
+  onToggle,
+  staggerClass,
+}: MtrLineCardProps) {
+  const upTrains = payload.UP ?? []
+  const downTrains = payload.DOWN ?? []
+  const totalTrains = upTrains.length + downTrains.length
+  const expandable = totalTrains > 1
+
+  const computeUniqueDestEtas = React.useCallback(
+    (trains: MtrTrainEntry[], dir: MtrDirection) => {
+      const seenDests = new Set<string>()
+      return (trains ?? [])
+        .map((train) => {
+          const route = String((train as { route?: unknown }).route ?? '')
+          const showViaRacecourse = shouldShowViaRacecourse({
+            line,
+            currentSta: sta,
+            dir,
+            route: route || undefined,
+          })
+          const dest = formatDestWithRacecourse(train.dest, lang, showViaRacecourse)
+          const platform = formatPlatform(train.plat)
+          const eta = formatMinutes(train.ttnt, lang)
+          return { dest, platform, eta, key: `${dest}-${route}` }
+        })
+        .filter((item) => {
+          if (!item.dest || seenDests.has(item.dest)) return false
+          seenDests.add(item.dest)
+          return true
+        })
+    },
+    [line, sta, lang]
+  )
+
+  const collapsedItems = [
+    ...computeUniqueDestEtas(upTrains, 'UP'),
+    ...computeUniqueDestEtas(downTrains, 'DOWN'),
+  ]
+
+  const collapsedSummary = (
+    <div className="space-y-1">
+      {collapsedItems.length === 0 ? (
+        <div className="text-on-surface-variant m3-body-md">—</div>
+      ) : (
+        collapsedItems.map((item) => (
+          <div key={item.key} className="flex items-center justify-between gap-3 py-0.5">
+            <Marquee className="text-on-surface m3-body-md min-w-0 flex-1 font-medium">
+              {item.dest}
+            </Marquee>
+            <div className="flex shrink-0 items-center gap-2">
+              {item.platform ? (
+                <span className="text-on-surface-variant m3-label-md font-mono">
+                  P{item.platform}
+                </span>
+              ) : null}
+              {item.eta.arriving ? (
+                <span className="bg-primary-container text-on-primary-container m3-label-lg font-tabular flex items-center gap-1.5 rounded-full px-2.5 py-0.5 font-semibold">
+                  <LivePulse />
+                  {item.eta.text}
+                </span>
+              ) : (
+                <span className="text-on-surface font-tabular m3-body-md font-semibold">
+                  {item.eta.text}
+                </span>
+              )}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  )
+
+  const trainRow = (train: MtrTrainEntry, dir: MtrDirection, trainIdx: number) => {
+    const route = String((train as { route?: unknown }).route ?? '')
+    const showViaRacecourse = shouldShowViaRacecourse({
+      line,
+      currentSta: sta,
+      dir,
+      route: route || undefined,
+    })
+    const destText = formatDestWithRacecourse(train.dest, lang, showViaRacecourse)
+    const platform = formatPlatform(train.plat)
+    const eta = formatMinutes(train.ttnt, lang)
+
+    return (
+      <div key={`${dir}-${trainIdx}`} className="flex items-center justify-between gap-3 py-1.5">
+        <Marquee className="text-on-surface m3-body-md min-w-0 flex-1 font-medium">
+          {destText}
+        </Marquee>
+        <div className="flex shrink-0 items-center gap-2">
+          {platform ? (
+            <span className="text-on-surface-variant m3-label-md font-mono">P{platform}</span>
+          ) : null}
+          {eta.arriving ? (
+            <span className="bg-primary-container text-on-primary-container m3-label-lg font-tabular flex items-center gap-1.5 rounded-full px-2.5 py-0.5 font-semibold">
+              <LivePulse />
+              {eta.text}
+            </span>
+          ) : (
+            <span className="text-on-surface font-tabular m3-body-md font-semibold">
+              {eta.text}
+            </span>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const expandedPanel = (
+    <div className="space-y-4">
+      <div>
+        <div className="text-on-surface-variant m3-label-md mb-1 font-medium">{upLabel}</div>
+        <div className="space-y-1">
+          {upTrains.length === 0 ? (
+            <div className="text-on-surface-variant m3-body-md">—</div>
+          ) : (
+            upTrains.slice(0, 4).map((train, idx) => trainRow(train, 'UP', idx))
+          )}
+        </div>
+      </div>
+      <div>
+        <div className="text-on-surface-variant m3-label-md mb-1 font-medium">{downLabel}</div>
+        <div className="space-y-1">
+          {downTrains.length === 0 ? (
+            <div className="text-on-surface-variant m3-body-md">—</div>
+          ) : (
+            downTrains.slice(0, 4).map((train, idx) => trainRow(train, 'DOWN', idx))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+
+  const header = (includeChevron: boolean) =>
+    line ? (
+      <div
+        className={cn(
+          'flex items-center justify-between px-4 py-3',
+          lineColor ? getReadableForeground(lineColor) : 'text-on-surface'
+        )}
+        style={{ backgroundColor: lineColor }}
+      >
+        <span className="m3-title-md font-medium">{line}</span>
+        {includeChevron ? (
+          expanded ? (
+            <ChevronUp className="h-4 w-4" />
+          ) : (
+            <ChevronDown className="h-4 w-4" />
+          )
+        ) : null}
+      </div>
+    ) : null
+
+  if (!expandable) {
+    return (
+      <div className={cn('overflow-hidden rounded-2xl', staggerClass)}>
+        {header(false)}
+        <div className="bg-surface-container p-4">{collapsedSummary}</div>
+      </div>
+    )
+  }
+
+  return (
+    <ExpandableEtaRow
+      expanded={expanded}
+      onToggle={onToggle}
+      className="ui-lift"
+      panel={expandedPanel}
+    >
+      <div className="-mt-3 -mr-3 -ml-4">{header(true)}</div>
+      {expanded ? null : <div className="pt-2">{collapsedSummary}</div>}
+    </ExpandableEtaRow>
+  )
 }
 
 export const MtrResults = React.memo(function MtrResults({
@@ -214,8 +413,6 @@ export const MtrResults = React.memo(function MtrResults({
         ) : (
           Object.entries(schedule.data ?? {}).map(([key, payload], idx) => {
             const [line, sta] = key.split('-')
-            const station = sta ? findMtrStationBySta(sta) : undefined
-            const stationName = station ? (lang === 'en' ? station.nameEn : station.nameTc) : sta
             const lineColor = line ? getLineColor(line) : undefined
 
             const staggerClass =
@@ -228,179 +425,19 @@ export const MtrResults = React.memo(function MtrResults({
                     : ''
 
             return (
-              <div key={key} className={cn('relative pb-4', staggerClass)}>
-                {lineColor ? (
-                  <span
-                    className="absolute top-0 bottom-4 left-0 w-[3px] rounded-full"
-                    style={{ backgroundColor: lineColor }}
-                    aria-hidden
-                  />
-                ) : null}
-                <div className="flex min-w-0 items-center gap-2 pb-3 pl-3">
-                  {line ? (
-                    <Badge
-                      className={cn(
-                        'rounded-lg ring-1 ring-black/10',
-                        getReadableForeground(getLineColor(line))
-                      )}
-                      style={{ backgroundColor: getLineColor(line) }}
-                    >
-                      {line}
-                    </Badge>
-                  ) : null}
-                  <div className="text-on-surface m3-title-md min-w-0 truncate">
-                    {stationName ?? key}
-                  </div>
-                </div>
-
-                <div className="space-y-2 pl-3">
-                  {(['UP', 'DOWN'] as const).map((dir) => {
-                    const trains = payload[dir] ?? []
-                    const dirKey = `${key}-${dir}`
-                    const expanded = expandedKey === dirKey
-                    const expandable = trains.length > 1
-
-                    const first = trains[0]
-                    const firstRoute = String((first as { route?: unknown })?.route ?? '')
-                    const firstShowViaRacecourse = first
-                      ? shouldShowViaRacecourse({
-                          line,
-                          currentSta: sta,
-                          dir,
-                          route: firstRoute || undefined,
-                        })
-                      : false
-                    const firstDest = first
-                      ? formatDestWithRacecourse(first.dest, lang, firstShowViaRacecourse)
-                      : ''
-                    const firstPlatform = first ? formatPlatform(first.plat) : ''
-                    const firstEta = first
-                      ? formatMinutes(first.ttnt, lang)
-                      : { text: '—', arriving: false }
-
-                    const directionLabel = dir === 'UP' ? t.up : t.down
-
-                    const header = (
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="text-on-surface-variant m3-label-md font-medium">
-                          {directionLabel}
-                        </span>
-                        {expanded ? null : (
-                          <div className="flex min-w-0 shrink-0 items-center gap-2">
-                            {firstPlatform ? (
-                              <span className="text-on-surface-variant m3-label-md font-mono">
-                                P{firstPlatform}
-                              </span>
-                            ) : null}
-                            <Marquee className="text-on-surface m3-body-md hidden max-w-[12rem] font-medium sm:block">
-                              {firstDest}
-                            </Marquee>
-                            {firstEta.arriving ? (
-                              <span className="bg-primary-container text-on-primary-container m3-label-lg font-tabular flex items-center gap-1.5 rounded-full px-2.5 py-0.5 font-semibold">
-                                <LivePulse />
-                                {firstEta.text}
-                              </span>
-                            ) : (
-                              <span className="text-on-surface font-tabular m3-body-md font-semibold">
-                                {firstEta.text}
-                              </span>
-                            )}
-                            {expanded ? (
-                              <ChevronUp className="text-on-surface-variant h-4 w-4" />
-                            ) : (
-                              <ChevronDown className="text-on-surface-variant h-4 w-4" />
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    )
-
-                    const trainList = (
-                      <div className="space-y-1">
-                        {trains.length === 0 ? (
-                          <div className="text-on-surface-variant m3-body-md">—</div>
-                        ) : (
-                          trains.slice(0, 4).map((train, trainIdx) => {
-                            const route = String((train as { route?: unknown }).route ?? '')
-                            const showViaRacecourse = shouldShowViaRacecourse({
-                              line,
-                              currentSta: sta,
-                              dir,
-                              route: route || undefined,
-                            })
-                            const destText = formatDestWithRacecourse(
-                              train.dest,
-                              lang,
-                              showViaRacecourse
-                            )
-                            const platform = formatPlatform(train.plat)
-                            const eta = formatMinutes(train.ttnt, lang)
-
-                            return (
-                              <div
-                                key={`${dir}-${trainIdx}`}
-                                className="flex items-center justify-between gap-3 py-1.5"
-                              >
-                                <Marquee className="text-on-surface m3-body-md min-w-0 flex-1 font-medium">
-                                  {destText}
-                                </Marquee>
-                                <div className="flex shrink-0 items-center gap-2">
-                                  {platform ? (
-                                    <span className="text-on-surface-variant m3-label-md font-mono">
-                                      P{platform}
-                                    </span>
-                                  ) : null}
-                                  {eta.arriving ? (
-                                    <span className="bg-primary-container text-on-primary-container m3-label-lg font-tabular flex items-center gap-1.5 rounded-full px-2.5 py-0.5 font-semibold">
-                                      <LivePulse />
-                                      {eta.text}
-                                    </span>
-                                  ) : (
-                                    <span className="text-on-surface font-tabular m3-body-md font-semibold">
-                                      {eta.text}
-                                    </span>
-                                  )}
-                                </div>
-                              </div>
-                            )
-                          })
-                        )}
-                      </div>
-                    )
-
-                    if (!expandable) {
-                      return (
-                        <div
-                          key={dirKey}
-                          className="bg-surface-container relative overflow-hidden rounded-2xl p-3"
-                        >
-                          {lineColor ? (
-                            <span
-                              className="absolute inset-y-2 left-0 w-[3px] rounded-full"
-                              style={{ backgroundColor: lineColor }}
-                              aria-hidden
-                            />
-                          ) : null}
-                          <div className="pl-3">{header}</div>
-                        </div>
-                      )
-                    }
-
-                    return (
-                      <ExpandableEtaRow
-                        key={dirKey}
-                        expanded={expanded}
-                        onToggle={() => onToggleExpand(dirKey)}
-                        color={lineColor}
-                        className="ui-lift"
-                        panel={trainList}
-                      >
-                        {header}
-                      </ExpandableEtaRow>
-                    )
-                  })}
-                </div>
-              </div>
+              <MtrLineCard
+                key={key}
+                payload={payload}
+                line={line}
+                sta={sta}
+                lang={lang}
+                lineColor={lineColor}
+                upLabel={t.up}
+                downLabel={t.down}
+                expanded={expandedKey === key}
+                onToggle={() => onToggleExpand(key)}
+                staggerClass={staggerClass}
+              />
             )
           })
         )}


### PR DESCRIPTION
## Summary

- Replaces the per-direction expandable rows with a single line-level card that shows unique destinations collapsed by default
- Introduces `MtrLineCard` component that consolidates UP/DOWN trains into one card with a collapsed summary view
- Non-expandable cards (single train) render as simple static blocks without toggle affordance
- Removes per-direction expand/collapse in favor of per-line expand/collapse
- Adjusts expand/collapse animation easing for a smoother feel

## Testing

- Verified collapsed card shows one row per unique destination with correct platform and ETA
- Verified expanded card shows all trains (up to 4 per direction) with direction headers
- Verified single-train lines render as non-interactive cards with no chevron
- Verified transition animation easing change produces a smoother open/close motion
- Checked stale-data fallback renders `—` placeholder in both collapsed and expanded states
- Not run: visual regression tests (no VRT pipeline set up)