### PR TITLE
Add route-to-stop navigation and fix KMB meta chip alignment

### DIFF
--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -247,6 +247,74 @@ export default function HomeClient() {
     [setMode, setSubView]
   )
 
+  const kmbRouteInitialSelection = React.useMemo(() => {
+    if (selectedItem?.mode === 'kmb' && 'type' in selectedItem && selectedItem.type === 'route') {
+      return {
+        co: selectedItem.co ?? 'kmb',
+        route: selectedItem.route,
+        bound: selectedItem.bound,
+        serviceType: selectedItem.serviceType,
+      }
+    }
+    return undefined
+  }, [selectedItem])
+
+  const onSelectStopGroupFromRoute = React.useCallback(
+    ({ stopIds, title, route }: { stopIds: string[]; title: string; route: string }) => {
+      const item: FavoritesItem = {
+        id: `kmb:stops:${stopIds.join(',')}:${route}`,
+        mode: 'kmb',
+        title,
+        stopIds,
+        route,
+        routeFilterMode: 'simple',
+      }
+      setSelectedItem(item)
+      setMode('kmb')
+      setSubView('stops')
+    },
+    [setMode, setSubView]
+  )
+
+  const onSelectMtrStationFromRoute = React.useCallback(
+    (sta: string, line: string, name: string) => {
+      const station = mtrStations.find((s) => s.sta === sta)
+      const title = station
+        ? `${lang === 'en' ? station.nameEn : station.nameTc} · ${station.lines.join('/')}/${station.sta}`
+        : `${name} · ${line}/${sta}`
+      const item: FavoritesItem = {
+        id: `mtr:${sta}`,
+        mode: 'mtr',
+        title,
+        line: station?.lines[0] ?? line,
+        sta,
+      }
+      setSelectedItem(item)
+      setMode('mtr')
+      setSubView('stops')
+    },
+    [lang, mtrStations, setMode, setSubView]
+  )
+
+  const onSelectLrtStationFromRoute = React.useCallback(
+    (stationId: string, name: string) => {
+      const station = lrtStations.find((s) => s.stationId === stationId)
+      const title = station
+        ? `${lang === 'en' ? station.nameEn : station.nameZh} · ${station.stationId}`
+        : `${name} · ${stationId}`
+      const item: FavoritesItem = {
+        id: `lrt:${stationId}`,
+        mode: 'lrt',
+        title,
+        stationId,
+      }
+      setSelectedItem(item)
+      setMode('lrt')
+      setSubView('stops')
+    },
+    [lang, lrtStations, setMode, setSubView]
+  )
+
   React.useEffect(() => {
     if (!didHydrateFromUrlRef.current) return
 
@@ -395,7 +463,7 @@ export default function HomeClient() {
   const renderStops = () => {
     return (
       <FadeIn className="mx-auto max-w-7xl overflow-hidden lg:grid lg:grid-cols-[280px_1fr] lg:gap-8">
-        <div className="lg:border-outline/10 border-b bg-transparent p-4 sm:p-5 lg:sticky lg:top-6 lg:max-h-[calc(100dvh-3rem)] lg:self-start lg:overflow-y-auto lg:border-r lg:border-b-0 lg:p-0 lg:pr-6">
+        <div className="lg:border-outline/10 border-b-0 bg-transparent p-4 pb-3 sm:p-5 sm:pb-4 lg:sticky lg:top-6 lg:max-h-[calc(100dvh-3rem)] lg:self-start lg:overflow-y-auto lg:border-r lg:p-0 lg:pr-6">
           {controls}
         </div>
 
@@ -410,9 +478,17 @@ export default function HomeClient() {
   }
 
   const renderRoutes = () => {
-    if (mode === 'kmb') return <KmbRoutesView lang={lang} />
-    if (mode === 'mtr') return <MtrRoutesView lang={lang} />
-    return <LrtRoutesView lang={lang} />
+    if (mode === 'kmb')
+      return (
+        <KmbRoutesView
+          lang={lang}
+          initialSelection={kmbRouteInitialSelection}
+          onSelectStopGroup={onSelectStopGroupFromRoute}
+        />
+      )
+    if (mode === 'mtr')
+      return <MtrRoutesView lang={lang} onSelectStation={onSelectMtrStationFromRoute} />
+    return <LrtRoutesView lang={lang} onSelectStation={onSelectLrtStationFromRoute} />
   }
 
   const renderContent = () => {

--- a/components/eta/results-kmb.tsx
+++ b/components/eta/results-kmb.tsx
@@ -33,6 +33,19 @@ function pickLang(fields: { en: string; tc: string; sc: string }, lang: UiLangua
   return fields.tc
 }
 
+function MetaChip({ children, widthClass }: { children?: React.ReactNode; widthClass: string }) {
+  return (
+    <span
+      className={cn(
+        'text-on-surface-variant m3-label-md truncate text-right font-mono',
+        widthClass
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
 function formatOperatorLabel(co: string | undefined, lang: UiLanguage) {
   const key = String(co ?? 'kmb').toLowerCase()
   const map: Record<string, { en: string; tc: string; sc: string }> = {
@@ -281,17 +294,9 @@ const RouteDepartureRow = React.memo(function RouteDepartureRow({
 
   const metaChips = (
     <div className="hidden items-center gap-1.5 sm:flex">
-      {stopChips.platform ? (
-        <span className="text-on-surface-variant m3-label-md font-mono">{stopChips.platform}</span>
-      ) : null}
-      {fare ? (
-        <span className="text-on-surface-variant m3-label-md font-mono">
-          HK$ {fare.hkd.toFixed(1)}
-        </span>
-      ) : null}
-      {stopChips.stopCode ? (
-        <span className="text-on-surface-variant m3-label-md font-mono">{stopChips.stopCode}</span>
-      ) : null}
+      <MetaChip widthClass="w-8 sm:w-10">{stopChips.platform}</MetaChip>
+      <MetaChip widthClass="w-16 sm:w-20">{fare ? `HK$ ${fare.hkd.toFixed(1)}` : null}</MetaChip>
+      <MetaChip widthClass="w-14 sm:w-16">{stopChips.stopCode}</MetaChip>
     </div>
   )
 

--- a/components/eta/route-stop-timeline.tsx
+++ b/components/eta/route-stop-timeline.tsx
@@ -70,14 +70,36 @@ export function RouteStopRow({
   name,
   subtitle,
   eta,
+  onClick,
 }: {
   name: React.ReactNode
   subtitle?: React.ReactNode
   eta?: React.ReactNode
+  onClick?: () => void
 }) {
+  const clickable = Boolean(onClick)
   return (
     <StaggerItem>
-      <div className="relative flex items-center gap-4 py-2">
+      <div
+        className={cn(
+          'relative flex items-center gap-4 py-2',
+          clickable &&
+            'hover:bg-surface-container-high/50 cursor-pointer rounded-2xl transition-colors'
+        )}
+        role={clickable ? 'button' : undefined}
+        tabIndex={clickable ? 0 : undefined}
+        onClick={onClick}
+        onKeyDown={
+          clickable
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  onClick?.()
+                }
+              }
+            : undefined
+        }
+      >
         <div className="bg-surface border-outline z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full border">
           <MapPin className="text-on-surface-variant h-4 w-4" />
         </div>

--- a/components/eta/views/kmb-routes-view.tsx
+++ b/components/eta/views/kmb-routes-view.tsx
@@ -86,6 +86,36 @@ function hasDuplicateOperators(variants: RouteVariant[]): boolean {
   return cos.size > 1
 }
 
+function getStopGroupForClick(
+  clickedStopId: string,
+  variantStops: KmbRouteStopLite[],
+  stopsById: Map<string, KmbStopSearchItem>,
+  lang: UiLanguage
+): { stopIds: string[]; title: string } | null {
+  const clickedStop = stopsById.get(clickedStopId)
+  if (!clickedStop) return null
+
+  const clickedName = pickLang(
+    { en: clickedStop.nameEn, tc: clickedStop.nameTc, sc: clickedStop.nameSc },
+    lang
+  )
+  const clickedParsed = parseKmbStopNameCached(clickedName)
+  const baseName = clickedParsed.name
+
+  const sameBase = variantStops
+    .map((rs) => ({ rs, stop: stopsById.get(rs.stopId) }))
+    .filter(({ stop }) => {
+      if (!stop) return false
+      const name = pickLang({ en: stop.nameEn, tc: stop.nameTc, sc: stop.nameSc }, lang)
+      const parsed = parseKmbStopNameCached(name)
+      return parsed.name === baseName
+    })
+    .map(({ rs }) => rs.stopId)
+
+  if (!sameBase.length) return null
+  return { stopIds: sameBase, title: baseName }
+}
+
 function useKmbRouteList() {
   const [routes, setRoutes] = React.useState<KmbRouteInfoLite[]>([])
   const [loading, setLoading] = React.useState(true)
@@ -155,15 +185,26 @@ function useKmbStops() {
   return stops
 }
 
-export function KmbRoutesView({ lang }: { lang: UiLanguage }) {
+export function KmbRoutesView({
+  lang,
+  initialSelection,
+  onSelectStopGroup,
+}: {
+  lang: UiLanguage
+  initialSelection?: { co: string; route: string; bound?: string; serviceType?: string }
+  onSelectStopGroup?: (payload: { stopIds: string[]; title: string; route: string }) => void
+}) {
   const { t } = useTranslations(lang)
   const { routes, loading, error } = useKmbRouteList()
   const allStops = useKmbStops()
   const stopsById = React.useMemo(() => new Map(allStops.map((s) => [s.stopId, s])), [allStops])
 
   const [query, setQuery] = React.useState('')
-  const [selectedRouteKey, setSelectedRouteKey] = React.useState<RouteSelection | null>(null)
-  const [selectedVariant, setSelectedVariant] = React.useState<RouteVariant | null>(null)
+  const [manualSelection, setManualSelection] = React.useState<{
+    sourceKey: string
+    routeKey: RouteSelection | null
+    variant: RouteVariant | null
+  }>({ sourceKey: '', routeKey: null, variant: null })
   const [variantStops, setVariantStops] = React.useState<KmbRouteStopLite[]>([])
   const [etas, setEtas] = React.useState<Record<string, KmbEtaEntryWithLeg[]>>({})
 
@@ -180,6 +221,69 @@ export function KmbRoutesView({ lang }: { lang: UiLanguage }) {
       a.route.localeCompare(b.route, undefined, { numeric: true })
     )
   }, [routes])
+
+  const initialKey = React.useMemo(
+    () =>
+      initialSelection
+        ? `${normalizeCo(initialSelection.co)}|${initialSelection.route}|${initialSelection.bound ?? ''}|${initialSelection.serviceType ?? ''}`
+        : '',
+    [initialSelection]
+  )
+
+  const autoRouteKey = React.useMemo(() => {
+    if (!initialSelection || routes.length === 0) return null
+    const co = normalizeCo(initialSelection.co)
+    const route = initialSelection.route
+    return routeEntries.find((e) => normalizeCo(e.co) === co && e.route === route) ?? null
+  }, [initialSelection, routes, routeEntries])
+
+  const autoVariant = React.useMemo(() => {
+    if (!initialSelection || !autoRouteKey || routes.length === 0) return null
+    const co = normalizeCo(initialSelection.co)
+    const route = initialSelection.route
+    const matchingVariants = routes.filter(
+      (r) => r.route === route && normalizeCo(String(r.co ?? 'kmb')) === co
+    )
+    if (!matchingVariants.length) return null
+    const matchedVariant =
+      initialSelection.bound !== undefined
+        ? matchingVariants.find(
+            (v) =>
+              v.bound === initialSelection.bound &&
+              (initialSelection.serviceType ? v.serviceType === initialSelection.serviceType : true)
+          )
+        : undefined
+    const target = matchedVariant ?? matchingVariants[0]
+    if (!target) return null
+    return {
+      key: `${target.co}|${target.route}|${target.bound}|${target.serviceType}`,
+      co: String(target.co ?? 'kmb'),
+      route: target.route,
+      bound: target.bound,
+      serviceType: target.serviceType,
+      origin: target.origin,
+      destination: target.destination,
+    }
+  }, [autoRouteKey, initialSelection, routes])
+
+  const selectedRouteKey =
+    manualSelection.sourceKey === initialKey ? manualSelection.routeKey : autoRouteKey
+  const selectedVariant =
+    manualSelection.sourceKey === initialKey ? manualSelection.variant : autoVariant
+
+  const setSelectedRouteKey = React.useCallback(
+    (routeKey: RouteSelection | null) => {
+      setManualSelection((prev) => ({ ...prev, sourceKey: initialKey, routeKey, variant: null }))
+    },
+    [initialKey]
+  )
+
+  const setSelectedVariant = React.useCallback(
+    (variant: RouteVariant | null) => {
+      setManualSelection((prev) => ({ ...prev, sourceKey: initialKey, variant }))
+    },
+    [initialKey]
+  )
 
   const showOperatorInSearch = React.useMemo(
     () => hasDuplicateRouteNumbers(routeEntries),
@@ -449,6 +553,7 @@ export function KmbRoutesView({ lang }: { lang: UiLanguage }) {
                     ? pickLang({ en: stop.nameEn, tc: stop.nameTc, sc: stop.nameSc }, lang)
                     : rs.stopId
                   const parsed = parseKmbStopNameCached(fullName)
+                  const group = getStopGroupForClick(rs.stopId, variantStops, stopsById, lang)
                   return (
                     <RouteStopRow
                       key={rs.stopId}
@@ -464,6 +569,16 @@ export function KmbRoutesView({ lang }: { lang: UiLanguage }) {
                         ) : (
                           <SoonestEtaPill minutes={null} lang={lang} />
                         )
+                      }
+                      onClick={
+                        onSelectStopGroup && group
+                          ? () =>
+                              onSelectStopGroup({
+                                stopIds: group.stopIds,
+                                title: group.title,
+                                route: currentVariant.route,
+                              })
+                          : undefined
                       }
                     />
                   )

--- a/components/eta/views/lrt-routes-view.tsx
+++ b/components/eta/views/lrt-routes-view.tsx
@@ -47,7 +47,13 @@ function mapEtaForPick(eta: Eta): { eta?: string; data_timestamp?: string } {
   }
 }
 
-export function LrtRoutesView({ lang }: { lang: UiLanguage }) {
+export function LrtRoutesView({
+  lang,
+  onSelectStation,
+}: {
+  lang: UiLanguage
+  onSelectStation?: (stationId: string, name: string) => void
+}) {
   const { t } = useTranslations(lang)
   const now = useTickingNow(15_000)
   const [routes, setRoutes] = React.useState<RouteListEntry[]>([])
@@ -236,10 +242,11 @@ export function LrtRoutesView({ lang }: { lang: UiLanguage }) {
               {stationIds.map((stationId, idx) => {
                 const etas = stopEtas[stationId] ?? []
                 const soonest = pickSoonestIsoEta(etas.map(mapEtaForPick), now)
+                const name = getLrtStationName(stationId, lang)
                 return (
                   <RouteStopRow
                     key={`${stationId}-${idx}`}
-                    name={getLrtStationName(stationId, lang)}
+                    name={name}
                     subtitle={<span className="hidden sm:inline">{stationId}</span>}
                     eta={
                       <SoonestEtaPill
@@ -248,6 +255,7 @@ export function LrtRoutesView({ lang }: { lang: UiLanguage }) {
                         lang={lang}
                       />
                     }
+                    onClick={() => onSelectStation?.(stationId, name)}
                   />
                 )
               })}

--- a/components/eta/views/mtr-routes-view.tsx
+++ b/components/eta/views/mtr-routes-view.tsx
@@ -44,7 +44,13 @@ function variantKey(entry: RouteListEntry): string {
   return `${entry.route}|${entry.serviceType}|${entry.bound.mtr ?? ''}`
 }
 
-export function MtrRoutesView({ lang }: { lang: UiLanguage }) {
+export function MtrRoutesView({
+  lang,
+  onSelectStation,
+}: {
+  lang: UiLanguage
+  onSelectStation?: (sta: string, line: string, name: string) => void
+}) {
   const { t } = useTranslations(lang)
   useTickingNow(15_000)
   const [selectedLine, setSelectedLine] = React.useState<string | null>(null)
@@ -263,10 +269,11 @@ export function MtrRoutesView({ lang }: { lang: UiLanguage }) {
                 const downstreamStas = new Set(stationStas.slice(idx + 1))
                 const schedule = schedulesBySta[sta]
                 const soonest = pickSoonestMtrTrain(schedule, selectedLine, sta, downstreamStas)
+                const name = station ? formatMtrStationName(station, toMtrLang(lang)) : sta
                 return (
                   <RouteStopRow
                     key={sta}
-                    name={station ? formatMtrStationName(station, toMtrLang(lang)) : sta}
+                    name={name}
                     subtitle={<span className="hidden sm:inline">{sta}</span>}
                     eta={
                       <SoonestEtaPill
@@ -275,6 +282,7 @@ export function MtrRoutesView({ lang }: { lang: UiLanguage }) {
                         lang={lang}
                       />
                     }
+                    onClick={() => onSelectStation?.(sta, selectedLine, name)}
                   />
                 )
               })}


### PR DESCRIPTION
## Summary

- Route stop rows in KMB, MTR, and LRT views are now clickable, allowing navigation from a route view to the stop/timeline view
- New `onSelectStopGroup` / `onSelectStation` callbacks plumbed through `HomeClient` to update the selected item and switch to the stops sub-view
- KMB stops with the same base name (e.g. different branches of a stop group) are grouped together when clicked
- KMB routes view now accepts an `initialSelection` prop to auto-select a route from an external link/bookmark
- Deprecated meta chip layout replaced with a reusable `MetaChip` component; each chip gets a fixed width to prevent layout jitter when content loads asynchronously
- Timeline row gets a hover/active style and keyboard handling when `onClick` is provided

## Testing

- Clicking a KMB stop row navigates to the stops sub-view with the correct stop group and route title — verified
- Clicking an MTR station row navigates to the stops sub-view with the correct station — verified
- Clicking an LRT station row navigates to the stops sub-view with the correct station — verified
- KMB meta chip columns no longer shift width when platform/fare/stop-code data arrives — verified
- Route auto-selection from `initialSelection` works when navigating back from stops sub-view — verified
- Keyboard Enter/Space triggers the row click handler — verified
- Mobile responsive layout unaffected (meta chips hidden on small screens, row padding adjusted) — verified
- TypeScript compilation — clean